### PR TITLE
[JSDK-24] compilation targets set to JDK 1.8

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,6 +16,16 @@ plugins {
 
 archivesBaseName = "truelayer-java"
 
+compileJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
+
+compileTestJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
+
 spotless {
     java {
         palantirJavaFormat()

--- a/lib/src/main/java/truelayer/java/TrueLayerClientBuilder.java
+++ b/lib/src/main/java/truelayer/java/TrueLayerClientBuilder.java
@@ -2,9 +2,11 @@ package truelayer.java;
 
 import java.util.Optional;
 import truelayer.java.auth.AuthenticationHandlerBuilder;
+import truelayer.java.auth.IAuthenticationHandler;
 import truelayer.java.configuration.Configuration;
 import truelayer.java.configuration.ConfigurationAssembler;
 import truelayer.java.hpp.HostedPaymentPageLinkBuilder;
+import truelayer.java.hpp.IHostedPaymentPageLinkBuilder;
 import truelayer.java.payments.PaymentHandler;
 
 /**
@@ -40,17 +42,17 @@ public class TrueLayerClientBuilder {
     public TrueLayerClient build() {
         Configuration configuration = new ConfigurationAssembler(this.useSandbox).assemble();
 
-        var clientCredentials =
+        ClientCredentials clientCredentials =
                 this.clientCredentials.orElseThrow(() -> new TrueLayerException("client credentials must be set"));
 
-        var authenticationHandler = AuthenticationHandlerBuilder.New()
+        IAuthenticationHandler authenticationHandler = AuthenticationHandlerBuilder.New()
                 .configuration(configuration)
                 .clientCredentials(clientCredentials)
                 .build();
 
         PaymentHandler paymentsHandler = null;
         if (this.signingOptions.isPresent()) {
-            var signingOptions =
+            SigningOptions signingOptions =
                     this.signingOptions.orElseThrow(() -> new TrueLayerException("signing options must be set"));
 
             paymentsHandler = PaymentHandler.New()
@@ -60,7 +62,7 @@ public class TrueLayerClientBuilder {
                     .build();
         }
 
-        var hppBuilder = HostedPaymentPageLinkBuilder.New()
+        IHostedPaymentPageLinkBuilder hppBuilder = HostedPaymentPageLinkBuilder.New()
                 .endpoint(configuration.hostedPaymentPage().endpointUrl())
                 .build();
 

--- a/lib/src/main/java/truelayer/java/auth/AuthenticationHandlerBuilder.java
+++ b/lib/src/main/java/truelayer/java/auth/AuthenticationHandlerBuilder.java
@@ -3,9 +3,12 @@ package truelayer.java.auth;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
 import truelayer.java.ClientCredentials;
 import truelayer.java.configuration.Configuration;
 import truelayer.java.http.HttpClientBuilder;
@@ -43,14 +46,14 @@ public class AuthenticationHandlerBuilder {
         notEmpty(clientCredentials.clientSecret(), "client secret must be not empty");
 
         // todo replace with non deprecated or custom implementation
-        var loggingInterceptor = new HttpLoggingInterceptor();
-        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        var networkInterceptors = List.<Interceptor>of(loggingInterceptor);
+        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.level(HttpLoggingInterceptor.Level.BODY);
+        List<Interceptor> networkInterceptors = Collections.singletonList(loggingInterceptor);
 
-        var applicationInterceptors =
-                List.of(new IdempotencyKeyInterceptor(), new UserAgentInterceptor(configuration.versionInfo()));
+        List<Interceptor> applicationInterceptors =
+                Arrays.asList(new IdempotencyKeyInterceptor(), new UserAgentInterceptor(configuration.versionInfo()));
 
-        var authHttpClient = new HttpClientBuilder()
+        Retrofit authHttpClient = new HttpClientBuilder()
                 .baseUrl(configuration.authentication().endpointUrl())
                 .applicationInterceptors(applicationInterceptors)
                 .networkInterceptors(networkInterceptors)

--- a/lib/src/main/java/truelayer/java/common/Utils.java
+++ b/lib/src/main/java/truelayer/java/common/Utils.java
@@ -11,7 +11,7 @@ public class Utils {
 
     public static ObjectMapper getObjectMapper() {
         if (OBJECT_MAPPER_INSTANCE == null) {
-            var objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = new ObjectMapper();
 
             // required for optionals deserialization
             objectMapper.registerModule(new Jdk8Module());

--- a/lib/src/main/java/truelayer/java/configuration/ConfigurationAssembler.java
+++ b/lib/src/main/java/truelayer/java/configuration/ConfigurationAssembler.java
@@ -8,6 +8,7 @@ import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import truelayer.java.TrueLayerException;
 import truelayer.java.common.Constants;
+import truelayer.java.configuration.Configuration.ConfigurationBuilder;
 
 public class ConfigurationAssembler {
     private static final String CONFIG_FILE_PREXIF = "truelayer-java";
@@ -19,7 +20,7 @@ public class ConfigurationAssembler {
     }
 
     public Configuration assemble() {
-        var configBuilder = Configuration.builder();
+        ConfigurationBuilder configBuilder = Configuration.builder();
 
         PropertiesConfiguration versionProps = getPropertiesFile("version");
 

--- a/lib/src/main/java/truelayer/java/hpp/HostedPaymentPageLinkBuilder.java
+++ b/lib/src/main/java/truelayer/java/hpp/HostedPaymentPageLinkBuilder.java
@@ -26,7 +26,7 @@ public class HostedPaymentPageLinkBuilder implements IHostedPaymentPageLinkBuild
             throw new TrueLayerException("return_uri must be set");
         }
 
-        var link = String.format(
+        String link = String.format(
                 "%s/payments#payment_id=%s&payment_token=%s&return_uri=%s",
                 endpoint, paymentId, payment_token, returnUri);
         return URI.create(link);

--- a/lib/src/main/java/truelayer/java/http/HttpClientBuilder.java
+++ b/lib/src/main/java/truelayer/java/http/HttpClientBuilder.java
@@ -39,7 +39,7 @@ public class HttpClientBuilder {
             throw new TrueLayerException("base url must be specified");
         }
 
-        var clientBuilder = new OkHttpClient.Builder();
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
 
         if (isNotEmpty(applicationInterceptors)) {
             applicationInterceptors.forEach(clientBuilder::addInterceptor);

--- a/lib/src/main/java/truelayer/java/http/interceptors/AuthenticationInterceptor.java
+++ b/lib/src/main/java/truelayer/java/http/interceptors/AuthenticationInterceptor.java
@@ -25,10 +25,10 @@ public class AuthenticationInterceptor implements Interceptor {
     @NotNull
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
-        var accessToken = tryGetToken(authenticationHandler.getOauthToken(scopes));
+        AccessToken accessToken = tryGetToken(authenticationHandler.getOauthToken(scopes));
 
         Request request = chain.request();
-        var newRequest = request.newBuilder()
+        Request newRequest = request.newBuilder()
                 .header(AUTHORIZATION, buildAuthorizationHeader(accessToken.getAccessToken()))
                 .build();
         return chain.proceed(newRequest);

--- a/lib/src/main/java/truelayer/java/http/interceptors/IdempotencyKeyInterceptor.java
+++ b/lib/src/main/java/truelayer/java/http/interceptors/IdempotencyKeyInterceptor.java
@@ -5,6 +5,7 @@ import static truelayer.java.common.Constants.HeaderNames.IDEMPOTENCY_KEY;
 import java.io.IOException;
 import java.util.UUID;
 import okhttp3.Interceptor;
+import okhttp3.Request;
 import okhttp3.Response;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,8 +13,8 @@ public class IdempotencyKeyInterceptor implements Interceptor {
     @NotNull
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
-        var request = chain.request();
-        var newRequest = request.newBuilder()
+        Request request = chain.request();
+        Request newRequest = request.newBuilder()
                 .header(IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .build();
 

--- a/lib/src/main/java/truelayer/java/http/interceptors/SignatureInterceptor.java
+++ b/lib/src/main/java/truelayer/java/http/interceptors/SignatureInterceptor.java
@@ -21,17 +21,17 @@ public class SignatureInterceptor implements Interceptor {
     @NotNull
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
-        var request = chain.request();
+        Request request = chain.request();
 
         if (needsSignature(request)) {
-            var clonedRequest = request.newBuilder().build();
+            Request clonedRequest = request.newBuilder().build();
 
-            var signature = computeSignature(
+            String signature = computeSignature(
                     clonedRequest.method().toLowerCase(),
                     clonedRequest.url().encodedPath(),
                     clonedRequest.header(IDEMPOTENCY_KEY),
                     getBodyAsString(clonedRequest));
-            var newRequest =
+            Request newRequest =
                     request.newBuilder().header(TL_SIGNATURE, signature).build();
             return chain.proceed(newRequest);
         }
@@ -40,7 +40,7 @@ public class SignatureInterceptor implements Interceptor {
     }
 
     private String getBodyAsString(Request request) throws IOException {
-        try (var buffer = new Buffer()) {
+        try (Buffer buffer = new Buffer()) {
             request.body().writeTo(buffer);
             return buffer.readUtf8();
         }

--- a/lib/src/main/java/truelayer/java/http/interceptors/UserAgentInterceptor.java
+++ b/lib/src/main/java/truelayer/java/http/interceptors/UserAgentInterceptor.java
@@ -16,7 +16,7 @@ public class UserAgentInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
-        var newRequest = request.newBuilder()
+        Request newRequest = request.newBuilder()
                 .header(USER_AGENT, String.format("%s/%s", versionInfo.libraryName(), versionInfo.libraryVersion()))
                 .build();
         return chain.proceed(newRequest);

--- a/lib/src/main/java/truelayer/java/payments/PaymentHandlerBuilder.java
+++ b/lib/src/main/java/truelayer/java/payments/PaymentHandlerBuilder.java
@@ -3,9 +3,12 @@ package truelayer.java.payments;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
 import truelayer.java.SigningOptions;
 import truelayer.java.auth.IAuthenticationHandler;
 import truelayer.java.configuration.Configuration;
@@ -45,18 +48,18 @@ public class PaymentHandlerBuilder {
         notNull(signingOptions.privateKey(), "private key must be not empty.");
 
         // todo replace with non deprecated or custom implementation
-        var loggingInterceptor = new HttpLoggingInterceptor();
-        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        var networkInterceptors = List.<Interceptor>of(loggingInterceptor);
+        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.level(HttpLoggingInterceptor.Level.BODY);
+        List<Interceptor> networkInterceptors = Collections.singletonList(loggingInterceptor);
 
-        var applicationInterceptors = List.of(
+        List<Interceptor> applicationInterceptors = Arrays.asList(
                 new IdempotencyKeyInterceptor(),
                 new UserAgentInterceptor(configuration.versionInfo()),
                 new SignatureInterceptor(signingOptions),
                 new AuthenticationInterceptor(
                         authenticationHandler, configuration.payments().scopes()));
 
-        var paymentHttpClient = new HttpClientBuilder()
+        Retrofit paymentHttpClient = new HttpClientBuilder()
                 .baseUrl(configuration.payments().endpointUrl())
                 .applicationInterceptors(applicationInterceptors)
                 .networkInterceptors(networkInterceptors)

--- a/lib/src/test/java/truelayer/java/TestUtils.java
+++ b/lib/src/test/java/truelayer/java/TestUtils.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static truelayer.java.common.Constants.HeaderNames.*;
 import static truelayer.java.common.Utils.getObjectMapper;
 
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -20,7 +22,6 @@ import truelayer.java.configuration.Configuration;
 import truelayer.java.configuration.Configuration.Endpoint;
 import truelayer.java.configuration.Configuration.Payments;
 import truelayer.java.http.entities.ApiResponse;
-import truelayer.java.http.entities.ProblemDetails;
 import truelayer.java.payments.entities.CreatePaymentResponse;
 import truelayer.java.payments.entities.User;
 import truelayer.java.payments.entities.beneficiary.MerchantAccount;
@@ -40,7 +41,7 @@ public class TestUtils {
     public static final String AN_AUTH_ENDPOINT = "https://auth.truelayer.com";
     public static final String A_PAYMENTS_ENDPOINT = "https://pay.truelayer.com";
 
-    public static final List A_PAYMENT_SCOPE = List.of("https://pay.truelayer.com");
+    public static final List A_PAYMENT_SCOPE = Collections.singletonList("https://pay.truelayer.com");
 
     public static ClientCredentials getClientCredentials() {
         return ClientCredentials.builder()
@@ -74,18 +75,12 @@ public class TestUtils {
 
     @SneakyThrows
     public static byte[] getPrivateKey() {
-        return Files.readAllBytes(Path.of(
+        return Files.readAllBytes(Paths.get(
                 new StringBuilder(KEYS_LOCATION).append("ec512-private-key.pem").toString()));
     }
 
-    @SneakyThrows
-    public static byte[] getPublicKey() {
-        return Files.readAllBytes(Path.of(
-                new StringBuilder(KEYS_LOCATION).append("ec512-public-key.pem").toString()));
-    }
-
     public static ApiResponse<AccessToken> buildAccessToken() {
-        var accessToken = new AccessToken(
+        AccessToken accessToken = new AccessToken(
                 UUID.randomUUID().toString(),
                 RandomUtils.nextInt(),
                 UUID.randomUUID().toString(),
@@ -101,7 +96,7 @@ public class TestUtils {
     }
 
     public static BasePaymentDetail buildGetPaymentByIdResponse() {
-        var payment = new AuthorizationRequiredPaymentDetail();
+        AuthorizationRequiredPaymentDetail payment = new AuthorizationRequiredPaymentDetail();
         payment.setId(UUID.randomUUID().toString());
         payment.setAmountInMinor(101);
         payment.setCurrency("GBP");
@@ -115,10 +110,6 @@ public class TestUtils {
         payment.setPaymentMethod(BankTransfer.builder().build());
         payment.setCreatedAt(new Date());
         return payment;
-    }
-
-    public static ProblemDetails buildError() {
-        return ProblemDetails.builder().title("an-error").build();
     }
 
     /**
@@ -135,7 +126,7 @@ public class TestUtils {
     public static <T> T deserializeJsonFileTo(String jsonFile, Class<T> type) {
         return getObjectMapper()
                 .readValue(
-                        Files.readAllBytes(Path.of(new StringBuilder(JSON_RESPONSES_LOCATION)
+                        Files.readAllBytes(Paths.get(new StringBuilder(JSON_RESPONSES_LOCATION)
                                 .append(jsonFile)
                                 .toString())),
                         type);
@@ -165,7 +156,7 @@ public class TestUtils {
             }
 
             public StubMapping build() {
-                var request = request(method.toUpperCase(), path)
+                MappingBuilder request = request(method.toUpperCase(), path)
                         .withHeader(IDEMPOTENCY_KEY, matching(UUID_REGEX_PATTERN))
                         .withHeader(USER_AGENT, matching(LIBRARY_INFO));
 

--- a/lib/src/test/java/truelayer/java/TrueLayerClientTests.java
+++ b/lib/src/test/java/truelayer/java/TrueLayerClientTests.java
@@ -6,6 +6,9 @@ import static truelayer.java.TestUtils.getClientCredentials;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import truelayer.java.auth.IAuthenticationHandler;
+import truelayer.java.hpp.IHostedPaymentPageLinkBuilder;
+import truelayer.java.payments.IPaymentHandler;
 
 public class TrueLayerClientTests {
 
@@ -13,10 +16,10 @@ public class TrueLayerClientTests {
     @DisplayName("It should yield an authentication handler")
     @SneakyThrows
     public void itShouldBuildAnAuthenticationHandler() {
-        var trueLayerClient =
+        ITrueLayerClient trueLayerClient =
                 TrueLayerClient.New().clientCredentials(getClientCredentials()).build();
 
-        var authenticationHandler = trueLayerClient.auth();
+        IAuthenticationHandler authenticationHandler = trueLayerClient.auth();
 
         assertNotNull(authenticationHandler);
     }
@@ -25,24 +28,24 @@ public class TrueLayerClientTests {
     @DisplayName("It should yield the same instance of the authentication handler if auth() is called multiple times")
     @SneakyThrows
     public void itShouldYieldTheSameAuthenticationHandler() {
-        var trueLayerClient =
+        ITrueLayerClient trueLayerClient =
                 TrueLayerClient.New().clientCredentials(getClientCredentials()).build();
 
-        var authenticationHandler1 = trueLayerClient.auth();
-        var authenticationHandler2 = trueLayerClient.auth();
+        IAuthenticationHandler authenticationHandler1 = trueLayerClient.auth();
+        IAuthenticationHandler authenticationHandler2 = trueLayerClient.auth();
 
-        assertTrue(authenticationHandler1 == authenticationHandler2);
+        assertSame(authenticationHandler1, authenticationHandler2);
     }
 
     @Test
     @DisplayName("It should yield a payment handler")
     public void itShouldBuildAPaymentClient() {
-        var trueLayerClient = TrueLayerClient.New()
+        ITrueLayerClient trueLayerClient = TrueLayerClient.New()
                 .clientCredentials(getClientCredentials())
                 .signingOptions(TestUtils.getSigningOptions())
                 .build();
 
-        var paymentsHandler = trueLayerClient.payments();
+        IPaymentHandler paymentsHandler = trueLayerClient.payments();
 
         assertNotNull(paymentsHandler);
     }
@@ -51,24 +54,24 @@ public class TrueLayerClientTests {
     @DisplayName("It should yield the same instance of the payment handler if payment() is called multiple times")
     @SneakyThrows
     public void itShouldYieldTheSamePaymentHandler() {
-        var trueLayerClient = TrueLayerClient.New()
+        ITrueLayerClient trueLayerClient = TrueLayerClient.New()
                 .clientCredentials(getClientCredentials())
                 .signingOptions(TestUtils.getSigningOptions())
                 .build();
 
-        var paymentHandler1 = trueLayerClient.payments();
-        var paymentHandler2 = trueLayerClient.payments();
+        IPaymentHandler paymentHandler1 = trueLayerClient.payments();
+        IPaymentHandler paymentHandler2 = trueLayerClient.payments();
 
-        assertTrue(paymentHandler1 == paymentHandler2);
+        assertSame(paymentHandler1, paymentHandler2);
     }
 
     @Test
     @DisplayName("It should yield an HPP link builder")
     public void itShouldBuildAnHppLinkBuilder() {
-        var trueLayerClient =
+        ITrueLayerClient trueLayerClient =
                 TrueLayerClient.New().clientCredentials(getClientCredentials()).build();
 
-        var hppLinkBuilder = trueLayerClient.hpp();
+        IHostedPaymentPageLinkBuilder hppLinkBuilder = trueLayerClient.hpp();
 
         assertNotNull(hppLinkBuilder);
     }
@@ -77,19 +80,19 @@ public class TrueLayerClientTests {
     @DisplayName("It should yield the same instance of the HPP link builder if hpp() is called multiple times")
     @SneakyThrows
     public void itShouldYieldTheSameHppLinkBuilder() {
-        var trueLayerClient =
+        ITrueLayerClient trueLayerClient =
                 TrueLayerClient.New().clientCredentials(getClientCredentials()).build();
 
-        var hpp1 = trueLayerClient.hpp();
-        var hpp2 = trueLayerClient.hpp();
+        IHostedPaymentPageLinkBuilder hpp1 = trueLayerClient.hpp();
+        IHostedPaymentPageLinkBuilder hpp2 = trueLayerClient.hpp();
 
-        assertTrue(hpp1 == hpp2);
+        assertSame(hpp1, hpp2);
     }
 
     @Test
     @DisplayName("It should throw an exception if credentials options are missing")
     public void itShouldBuildASandboxTrueLaterClient() {
-        var thrown = assertThrows(
+        Throwable thrown = assertThrows(
                 TrueLayerException.class, () -> TrueLayerClient.New().build());
 
         assertEquals("client credentials must be set", thrown.getMessage());
@@ -98,10 +101,10 @@ public class TrueLayerClientTests {
     @Test
     @DisplayName("It should throw an exception if signing options are missing")
     public void itShouldBuildAnExceptionIfSigningOptionMissing() {
-        var trueLayerClient =
+        ITrueLayerClient trueLayerClient =
                 TrueLayerClient.New().clientCredentials(getClientCredentials()).build();
 
-        var thrown = assertThrows(TrueLayerException.class, () -> trueLayerClient.payments());
+        Throwable thrown = assertThrows(TrueLayerException.class, () -> trueLayerClient.payments());
 
         assertEquals(
                 "payment handler not initialized. Make sure you specified the required signing options while initializing the library",

--- a/lib/src/test/java/truelayer/java/auth/AuthenticationHandlerBuilderTests.java
+++ b/lib/src/test/java/truelayer/java/auth/AuthenticationHandlerBuilderTests.java
@@ -12,7 +12,7 @@ class AuthenticationHandlerBuilderTests {
     @Test
     @DisplayName("It should yield an authentication handler")
     public void itShouldYieldAnAuthenticationHandler() {
-        var handler = AuthenticationHandlerBuilder.New()
+        AuthenticationHandler handler = AuthenticationHandlerBuilder.New()
                 .configuration(getConfiguration())
                 .clientCredentials(getClientCredentials())
                 .build();
@@ -24,7 +24,7 @@ class AuthenticationHandlerBuilderTests {
     @Test
     @DisplayName("It should throw and exception if credentials are missing")
     public void itShouldThrowExceptionIfCredentialsMissing() {
-        var thrown = assertThrows(NullPointerException.class, () -> AuthenticationHandlerBuilder.New()
+        Throwable thrown = assertThrows(NullPointerException.class, () -> AuthenticationHandlerBuilder.New()
                 .configuration(getConfiguration())
                 .build());
 

--- a/lib/src/test/java/truelayer/java/configuration/ConfigurationAssemblerTests.java
+++ b/lib/src/test/java/truelayer/java/configuration/ConfigurationAssemblerTests.java
@@ -2,7 +2,7 @@ package truelayer.java.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
+import java.util.Collections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,28 +11,28 @@ class ConfigurationAssemblerTests {
     @Test
     @DisplayName("It should build a live configuration object")
     public void itShouldBuildALiveConfiguration() {
-        var sut = new ConfigurationAssembler(false);
+        ConfigurationAssembler sut = new ConfigurationAssembler(false);
 
-        var config = sut.assemble();
+        Configuration config = sut.assemble();
 
         assertEquals("https://auth.truelayer.com", config.authentication().endpointUrl());
         assertEquals("https://test-pay-api.truelayer.com", config.payments().endpointUrl());
-        assertEquals(List.of("payments"), config.payments().scopes());
+        assertEquals(Collections.singletonList("payments"), config.payments().scopes());
         assertEquals("https://payment.truelayer.com", config.hostedPaymentPage().endpointUrl());
     }
 
     @Test
     @DisplayName("It should build a sandbox configuration object")
     public void itShouldBuildASandboxConfiguration() {
-        var sut = new ConfigurationAssembler(true);
+        ConfigurationAssembler sut = new ConfigurationAssembler(true);
 
-        var config = sut.assemble();
+        Configuration config = sut.assemble();
 
         assertEquals(
                 "https://auth.truelayer-sandbox.com", config.authentication().endpointUrl());
         assertEquals(
                 "https://test-pay-api.truelayer-sandbox.com", config.payments().endpointUrl());
-        assertEquals(List.of("payments"), config.payments().scopes());
+        assertEquals(Collections.singletonList("payments"), config.payments().scopes());
         assertEquals(
                 "https://payment.truelayer-sandbox.com",
                 config.hostedPaymentPage().endpointUrl());

--- a/lib/src/test/java/truelayer/java/hpp/HostedPaymentPageLinkBuilderTests.java
+++ b/lib/src/test/java/truelayer/java/hpp/HostedPaymentPageLinkBuilderTests.java
@@ -18,9 +18,9 @@ class HostedPaymentPageLinkBuilderTests {
     @Test
     @DisplayName("it should yield an HPP link with the given details")
     public void itShouldYieldAnHppLink() {
-        var sut = buildHppBuilder();
+        IHostedPaymentPageLinkBuilder sut = buildHppBuilder();
 
-        var link = sut.getHostedPaymentPageLink(A_PAYMENT_ID, A_PAYMENT_TOKEN, URI.create(A_RETURN_URI));
+        URI link = sut.getHostedPaymentPageLink(A_PAYMENT_ID, A_PAYMENT_TOKEN, URI.create(A_RETURN_URI));
 
         assertEquals(
                 new StringBuilder(A_HPP_ENDPOINT)
@@ -37,9 +37,9 @@ class HostedPaymentPageLinkBuilderTests {
     @Test
     @DisplayName("it should thrown an exception if redirect_uri is empty")
     public void itShouldThrowExceptionForEmptyRedirectUrl() {
-        var sut = buildHppBuilder();
+        IHostedPaymentPageLinkBuilder sut = buildHppBuilder();
 
-        var thrown = assertThrows(
+        Throwable thrown = assertThrows(
                 TrueLayerException.class,
                 () -> sut.getHostedPaymentPageLink(A_PAYMENT_ID, A_PAYMENT_TOKEN, URI.create("")));
 
@@ -49,9 +49,9 @@ class HostedPaymentPageLinkBuilderTests {
     @Test
     @DisplayName("it should thrown an exception if payment_id is empty")
     public void itShouldThrowExceptionForEmptyPaymentId() {
-        var sut = buildHppBuilder();
+        IHostedPaymentPageLinkBuilder sut = buildHppBuilder();
 
-        var thrown = assertThrows(
+        Throwable thrown = assertThrows(
                 TrueLayerException.class,
                 () -> sut.getHostedPaymentPageLink("", A_PAYMENT_TOKEN, URI.create(A_RETURN_URI)));
 
@@ -61,9 +61,9 @@ class HostedPaymentPageLinkBuilderTests {
     @Test
     @DisplayName("it should thrown an exception if payment_token is empty")
     public void itShouldThrowExceptionForEmptyResourceToken() {
-        var sut = buildHppBuilder();
+        IHostedPaymentPageLinkBuilder sut = buildHppBuilder();
 
-        var thrown = assertThrows(
+        Throwable thrown = assertThrows(
                 TrueLayerException.class,
                 () -> sut.getHostedPaymentPageLink(A_PAYMENT_ID, "", URI.create(A_RETURN_URI)));
 

--- a/lib/src/test/java/truelayer/java/http/HttpClientBuilderTests.java
+++ b/lib/src/test/java/truelayer/java/http/HttpClientBuilderTests.java
@@ -4,12 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collections;
 import okhttp3.Interceptor;
 import okhttp3.Response;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import retrofit2.Retrofit;
 import truelayer.java.TrueLayerException;
 
 class HttpClientBuilderTests {
@@ -19,7 +20,7 @@ class HttpClientBuilderTests {
     @Test
     @DisplayName("It should build an HTTP client with the given base URL")
     public void testCreation() {
-        var client = new HttpClientBuilder().baseUrl(A_BASE_URL).build();
+        Retrofit client = new HttpClientBuilder().baseUrl(A_BASE_URL).build();
 
         assertEquals(A_BASE_URL, client.baseUrl().toString());
     }
@@ -33,7 +34,7 @@ class HttpClientBuilderTests {
     @Test
     @DisplayName("It should build an HTTP client with the given base URL and interceptors")
     public void testCreationWithInterceptors() {
-        var dummyInterceptor = new Interceptor() {
+        Interceptor dummyInterceptor = new Interceptor() {
             @NotNull
             @Override
             public Response intercept(@NotNull Chain chain) throws IOException {
@@ -41,10 +42,10 @@ class HttpClientBuilderTests {
             }
         };
 
-        var client = new HttpClientBuilder()
+        Retrofit client = new HttpClientBuilder()
                 .baseUrl(A_BASE_URL)
-                .applicationInterceptors(List.of(dummyInterceptor))
-                .networkInterceptors(List.of(dummyInterceptor))
+                .applicationInterceptors(Collections.singletonList(dummyInterceptor))
+                .networkInterceptors(Collections.singletonList(dummyInterceptor))
                 .build();
 
         assertEquals(A_BASE_URL, client.baseUrl().toString());

--- a/lib/src/test/java/truelayer/java/http/interceptors/AuthenticationInterceptorTests.java
+++ b/lib/src/test/java/truelayer/java/http/interceptors/AuthenticationInterceptorTests.java
@@ -7,12 +7,14 @@ import static org.mockito.Mockito.when;
 import static truelayer.java.TestUtils.buildAccessToken;
 import static truelayer.java.common.Constants.HeaderNames.AUTHORIZATION;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import okhttp3.Interceptor;
 import org.junit.jupiter.api.*;
 import truelayer.java.TrueLayerException;
 import truelayer.java.auth.AuthenticationHandler;
+import truelayer.java.auth.IAuthenticationHandler;
 import truelayer.java.auth.entities.AccessToken;
 import truelayer.java.http.entities.ApiResponse;
 import truelayer.java.http.entities.ProblemDetails;
@@ -34,9 +36,9 @@ class AuthenticationInterceptorTests extends BaseInterceptorTests {
     @Test
     @DisplayName("It should add an authorization header to the original request")
     public void shouldAddAuthorizationHeader() {
-        var authenticationHandler = mock(AuthenticationHandler.class);
-        var scopes = List.of("payments");
-        var expectedAccessToken = buildAccessToken();
+        IAuthenticationHandler authenticationHandler = mock(AuthenticationHandler.class);
+        List<String> scopes = Collections.singletonList("payments");
+        ApiResponse<AccessToken> expectedAccessToken = buildAccessToken();
         when(authenticationHandler.getOauthToken(scopes))
                 .thenReturn(CompletableFuture.completedFuture(expectedAccessToken));
         this.interceptor = new AuthenticationInterceptor(authenticationHandler, scopes);
@@ -51,8 +53,8 @@ class AuthenticationInterceptorTests extends BaseInterceptorTests {
     @Test
     @DisplayName("It should throw an exception if authentication fails")
     public void shouldThrowException() {
-        var authenticationHandler = mock(AuthenticationHandler.class);
-        var scopes = List.of("payments");
+        IAuthenticationHandler authenticationHandler = mock(AuthenticationHandler.class);
+        List<String> scopes = Collections.singletonList("payments");
         when(authenticationHandler.getOauthToken(scopes))
                 .thenReturn(CompletableFuture.completedFuture(ApiResponse.<AccessToken>builder()
                         .error(ProblemDetails.builder()
@@ -62,7 +64,7 @@ class AuthenticationInterceptorTests extends BaseInterceptorTests {
                         .build()));
         this.interceptor = new AuthenticationInterceptor(authenticationHandler, scopes);
 
-        var thrown = Assertions.assertThrows(TrueLayerException.class, () -> intercept());
+        Throwable thrown = Assertions.assertThrows(TrueLayerException.class, () -> intercept());
 
         assertTrue(thrown.getMessage().startsWith("Unable to authenticate request"));
     }

--- a/lib/src/test/java/truelayer/java/http/interceptors/BaseInterceptorTests.java
+++ b/lib/src/test/java/truelayer/java/http/interceptors/BaseInterceptorTests.java
@@ -15,7 +15,8 @@ public abstract class BaseInterceptorTests {
     protected abstract Interceptor getInterceptor();
 
     protected void buildRequest() {
-        var request = new Request.Builder().url(HttpUrl.get("http://localhost")).build();
+        Request request =
+                new Request.Builder().url(HttpUrl.get("http://localhost")).build();
         chain = mock(Interceptor.Chain.class);
         when(chain.request()).thenReturn(request);
     }

--- a/lib/src/test/java/truelayer/java/payments/PaymentHandlerBuilderTests.java
+++ b/lib/src/test/java/truelayer/java/payments/PaymentHandlerBuilderTests.java
@@ -6,17 +6,18 @@ import static truelayer.java.TestUtils.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import truelayer.java.auth.AuthenticationHandlerBuilder;
+import truelayer.java.auth.IAuthenticationHandler;
 
 class PaymentHandlerBuilderTests {
 
     @Test
     @DisplayName("It should yield a payment handler")
     public void itShouldYieldAnAuthenticationHandler() {
-        var authHandler = AuthenticationHandlerBuilder.New()
+        IAuthenticationHandler authHandler = AuthenticationHandlerBuilder.New()
                 .configuration(getConfiguration())
                 .clientCredentials(getClientCredentials())
                 .build();
-        var paymentHandler = PaymentHandler.New()
+        PaymentHandler paymentHandler = PaymentHandler.New()
                 .configuration(getConfiguration())
                 .signingOptions(getSigningOptions())
                 .authenticationHandler(authHandler)
@@ -28,7 +29,7 @@ class PaymentHandlerBuilderTests {
     @Test
     @DisplayName("It should throw and exception if signing options are missing")
     public void itShouldThrowExceptionIfCredentialsMissing() {
-        var thrown = assertThrows(
+        Throwable thrown = assertThrows(
                 NullPointerException.class,
                 () -> PaymentHandler.New().configuration(getConfiguration()).build());
 

--- a/lib/src/test/java/truelayer/java/payments/entities/beneficiary/BaseBeneficiaryTests.java
+++ b/lib/src/test/java/truelayer/java/payments/entities/beneficiary/BaseBeneficiaryTests.java
@@ -14,7 +14,7 @@ class BaseBeneficiaryTests {
     public void shouldThrowAnExceptionIfMerchantIsAccessedAsExternalAccount() {
         BaseBeneficiary beneficiary = MerchantAccount.builder().build();
 
-        var thrown = Assertions.assertThrows(TrueLayerException.class, () -> beneficiary.asExternalAccount());
+        Throwable thrown = Assertions.assertThrows(TrueLayerException.class, () -> beneficiary.asExternalAccount());
         assertEquals(
                 "beneficiary is of type MerchantAccount. Consider using asMerchantAccount() instead.",
                 thrown.getMessage());
@@ -25,7 +25,7 @@ class BaseBeneficiaryTests {
     public void shouldThrowAnExceptionIfExternalIsAccessedAsMerchantAccount() {
         BaseBeneficiary beneficiary = ExternalAccount.builder().build();
 
-        var thrown = Assertions.assertThrows(TrueLayerException.class, () -> beneficiary.asMerchantAccount());
+        Throwable thrown = Assertions.assertThrows(TrueLayerException.class, () -> beneficiary.asMerchantAccount());
         assertEquals(
                 "beneficiary is of type ExternalAccount. Consider using asExternalAccount() instead.",
                 thrown.getMessage());

--- a/lib/src/test/java/truelayer/java/payments/entities/paymentdetail/BasePaymentDetailTests.java
+++ b/lib/src/test/java/truelayer/java/payments/entities/paymentdetail/BasePaymentDetailTests.java
@@ -14,7 +14,7 @@ class BasePaymentDetailTests {
     public void shouldGetAFailedPaymentDetail() {
         BasePaymentDetail p = new SettledPaymentDetail();
 
-        var thrown = Assertions.assertThrows(TrueLayerException.class, () -> p.asAuthorizingPaymentDetail());
+        Throwable thrown = Assertions.assertThrows(TrueLayerException.class, () -> p.asAuthorizingPaymentDetail());
         assertEquals(
                 "payment is of type SettledPaymentDetail. Consider using asSettledPaymentDetail() instead.",
                 thrown.getMessage());
@@ -25,7 +25,7 @@ class BasePaymentDetailTests {
     public void shouldThrowAnException() {
         BasePaymentDetail payment = new FailedPaymentDetail();
 
-        var failedPayment = payment.asFailedPaymentDetail();
+        FailedPaymentDetail failedPayment = payment.asFailedPaymentDetail();
         assertEquals(Status.FAILED, failedPayment.getStatus());
     }
 }


### PR DESCRIPTION
We want our library to work on older JVMs. This PR backports the project to Java 8: 
- source and target compatibility fixed on gradle build file
- removed collection factories like `List.of(...)`
- removed `var` declarations
- replaced JDK 11 `HttpClient` in tests with `HttpUrlConnection` 😱 