### PR TITLE
[JSDK-35] HPP: `payment_token` renamed to `resource_token`

### DIFF
--- a/lib/src/main/java/truelayer/java/hpp/HostedPaymentPageLinkBuilder.java
+++ b/lib/src/main/java/truelayer/java/hpp/HostedPaymentPageLinkBuilder.java
@@ -26,9 +26,8 @@ public class HostedPaymentPageLinkBuilder implements IHostedPaymentPageLinkBuild
             throw new TrueLayerException("return_uri must be set");
         }
 
-        // todo: change to payment_token to resource_token when the HPP is ready
         String link = String.format(
-                "%s/payments#payment_id=%s&payment_token=%s&return_uri=%s",
+                "%s/payments#payment_id=%s&resource_token=%s&return_uri=%s",
                 endpoint, paymentId, resource_token, returnUri);
         return URI.create(link);
     }

--- a/lib/src/test/java/truelayer/java/hpp/HostedPaymentPageLinkBuilderTests.java
+++ b/lib/src/test/java/truelayer/java/hpp/HostedPaymentPageLinkBuilderTests.java
@@ -25,7 +25,7 @@ class HostedPaymentPageLinkBuilderTests {
         assertEquals(
                 A_HPP_ENDPOINT + "/payments#payment_id="
                         + A_PAYMENT_ID
-                        + "&payment_token="
+                        + "&resource_token="
                         + A_RESOURCE_TOKEN
                         + "&return_uri="
                         + A_RETURN_URI,


### PR DESCRIPTION
Will release this once the relevant changes on HPP are deployed to sandbox and prod environments.
fyi @tl-sebastien-kovacs 