### PR TITLE
[JSDK-61] Adds support for unknown properties on response DTOs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=0.7.0
+version=0.7.1
 
 # Dependency properties
 retrofitVersion=2.9.0

--- a/src/main/java/com/truelayer/java/Utils.java
+++ b/src/main/java/com/truelayer/java/Utils.java
@@ -1,6 +1,7 @@
 package com.truelayer.java;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -23,6 +24,8 @@ public class Utils {
             objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
             // do not include null fields in JSON
             objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            // do not fail in case of unknown properties returned JSON payloads
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
             OBJECT_MAPPER_INSTANCE = objectMapper;
         }

--- a/src/main/java/com/truelayer/java/http/entities/ProblemDetails.java
+++ b/src/main/java/com/truelayer/java/http/entities/ProblemDetails.java
@@ -1,5 +1,8 @@
 package com.truelayer.java.http.entities;
 
+import static org.apache.commons.lang3.ObjectUtils.allNotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -22,4 +25,9 @@ public class ProblemDetails {
     private Integer status;
     private String traceId;
     private JsonNode errors;
+
+    @JsonIgnore
+    public boolean isWellFormed() {
+        return allNotNull(type, title, status);
+    }
 }

--- a/src/test/java/com/truelayer/java/UtilsTests.java
+++ b/src/test/java/com/truelayer/java/UtilsTests.java
@@ -1,0 +1,29 @@
+package com.truelayer.java;
+
+import static com.truelayer.java.TestUtils.*;
+import static com.truelayer.java.Utils.getObjectMapper;
+
+import com.truelayer.java.payments.entities.paymentdetail.SettledPaymentDetail;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for utilities
+ */
+public class UtilsTests {
+
+    @SneakyThrows
+    @Test
+    @DisplayName("It should deserialize a payment with an unknown response field")
+    public void itShouldDeserializeAPaymentWithUnknownResponseField() {
+        Assertions.assertDoesNotThrow(() -> getObjectMapper()
+                .readValue(
+                        Files.readAllBytes(Paths.get(JSON_RESPONSES_LOCATION
+                                + "payments/200.get_payment_by_id.unknown_response_field.json")),
+                        SettledPaymentDetail.class));
+    }
+}

--- a/src/test/java/com/truelayer/java/http/entities/ProblemDetailsTests.java
+++ b/src/test/java/com/truelayer/java/http/entities/ProblemDetailsTests.java
@@ -1,0 +1,29 @@
+package com.truelayer.java.http.entities;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ProblemDetailsTests {
+
+    @Test
+    @DisplayName("It should yield malformed")
+    public void itShouldYieldMalformed() {
+        ProblemDetails sut = ProblemDetails.builder().title("something").build();
+
+        assertFalse(sut.isWellFormed());
+    }
+
+    @Test
+    @DisplayName("It should yield well formed")
+    public void itShouldYieldWellFormed() {
+        ProblemDetails sut = ProblemDetails.builder()
+                .title("something")
+                .type("a-type")
+                .status(400)
+                .build();
+
+        assertTrue(sut.isWellFormed());
+    }
+}

--- a/src/test/resources/__files/payments/200.get_payment_by_id.unknown_response_field.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.unknown_response_field.json
@@ -1,0 +1,63 @@
+{
+  "id":"c7f3f6c5-ae17-4d43-829c-***",
+  "amount_in_minor":101,
+  "currency":"GBP",
+  "user":{
+    "id":"ac459f9f-37df-4cd7-ada5-***",
+    "name":"Andrea Di Lisio",
+    "email":"andrea@truelayer.com"
+  },
+  "this_is_new": "hello",
+  "payment_method":{
+    "type":"bank_transfer",
+    "provider_selection":{
+      "type":"user_selected",
+      "filter":{
+        "countries":[
+          "GB"
+        ],
+        "release_channel":"general_availability",
+        "customer_segments":[
+          "retail"
+        ],
+        "provider_ids":[
+          "mock-payments-gb-redirect"
+        ],
+        "excludes":{
+          "provider_ids":[
+            "ob-exclude-this-bank"
+          ]
+        }
+      }
+    },
+    "beneficiary":{
+      "type":"merchant_account",
+      "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
+      "account_holder_name":"john smith"
+    }
+  },
+  "created_at":"2022-01-17T17:13:18.214924Z",
+  "status":"settled",
+  "payment_source":{
+    "id":"1122hj-37df-4cd7-ada5-***",
+    "account_identifiers":[
+      {
+        "type":"iban",
+        "iban":"IT60X0542811101000000123456"
+      }
+    ],
+    "account_holder_name":"John Doe"
+  },
+  "succeeded_at":"2022-01-17T17:13:18.214924Z",
+  "settled_at":"2022-01-17T17:13:18.214924Z",
+  "authorization_flow":{
+    "configuration":{
+      "provider_selection":{
+        "status":"supported"
+      },
+      "redirect":{
+        "status":"not_supported"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

As per the current configuration an unknown (new) field in any of the API responses will lead to deserialization issue. 
As agreed with @tl-ozum-safaoglu this is too pedantic, therefore we're globally disabling this behavior on the SDK. 

The current setup was mostly meant to help us spot discrepancies between the expected and actual output of the APIs but we'll get the same control with other specific tools and processes in future. 

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation