### PR TITLE
[JSDK-62] Provider id and scheme id added in GET payment response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     // to publish packages
     id 'maven-publish'
     // code linting
-    id "com.diffplug.spotless" version "6.3.0"
+    id "com.diffplug.spotless" version "6.4.1"
     //  test coverage
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=0.7.1
+version=0.7.2
 
 # Dependency properties
 retrofitVersion=2.9.0

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/provider/PreselectedProviderSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/provider/PreselectedProviderSelection.java
@@ -10,9 +10,9 @@ import lombok.Getter;
 public class PreselectedProviderSelection extends ProviderSelection {
     private final Type type = Type.PRESELECTED;
 
-    private String providerId;
+    protected String providerId;
 
-    private SchemeId schemeId;
+    protected SchemeId schemeId;
 
     private Remitter remitter;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/provider/ProviderSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/provider/ProviderSelection.java
@@ -3,10 +3,7 @@ package com.truelayer.java.payments.entities.paymentmethod.provider;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @JsonTypeInfo(
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
@@ -29,6 +26,14 @@ public abstract class ProviderSelection {
 
     public static PreselectedProviderSelection.PreselectedProviderSelectionBuilder preselected() {
         return new PreselectedProviderSelection.PreselectedProviderSelectionBuilder();
+    }
+
+    public UserSelectedProviderSelection asUserSelected() {
+        return (UserSelectedProviderSelection) this;
+    }
+
+    public PreselectedProviderSelection asPreselected() {
+        return (PreselectedProviderSelection) this;
     }
 
     @RequiredArgsConstructor

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/provider/UserSelectedProviderSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/provider/UserSelectedProviderSelection.java
@@ -1,5 +1,6 @@
 package com.truelayer.java.payments.entities.paymentmethod.provider;
 
+import com.truelayer.java.payments.entities.SchemeId;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,6 +8,10 @@ import lombok.Getter;
 @Getter
 public class UserSelectedProviderSelection extends ProviderSelection {
     private final Type type = Type.USER_SELECTED;
+
+    protected String providerId;
+
+    protected SchemeId schemeId;
 
     private ProviderFilter filter;
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.settled.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.settled.json
@@ -27,7 +27,9 @@
             "ob-exclude-this-bank"
           ]
         }
-      }
+      },
+      "provider_id": "a-provider-id",
+      "scheme_id": "faster_payments_service"
     },
     "beneficiary":{
       "type":"merchant_account",


### PR DESCRIPTION
# Description

Adds provider id and scheme id support on GET Payment response objects. 
Relates to [PAYG-726]

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation

[PAYG-726]: https://truelayer.atlassian.net/browse/PAYG-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ