### PR TITLE
Dependabot and CVE-2020-36518 resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2'
 
     // Mocking libraries
-    def mockitoVersion='4.3.1'
+    def mockitoVersion = '4.3.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: mockitoVersion
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: mockitoVersion

--- a/build.gradle
+++ b/build.gradle
@@ -83,34 +83,38 @@ tasks.register('acceptance-tests', Test) {
 
 dependencies {
     // Utilities
-    implementation group: 'commons-beanutils', name: 'commons-beanutils', version: beanUtilsVersion
-    implementation group: 'org.apache.commons', name: 'commons-configuration2', version: apacheCommonsConfigurationVersion
+    implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.7'
 
     // HTTP client
+    def retrofitVersion = '2.9.0'
     implementation group: 'com.squareup.retrofit2', name: 'retrofit', version: retrofitVersion
     implementation group: 'com.squareup.retrofit2', name: 'converter-jackson', version: retrofitVersion
 
     // TL signing library
-    implementation group: 'com.truelayer', name: 'truelayer-signing', version: tlSigningVersion
+    implementation group: 'com.truelayer', name: 'truelayer-signing', version: '0.2.0'
 
     // Serialization
+    def jacksonVersion = '2.13.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: jacksonVersion
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
 
     // Logging
+    def tinyLogVersion = '2.4.1'
     implementation group: 'org.tinylog', name: 'tinylog-api', version: tinyLogVersion
     implementation group: 'org.tinylog', name: 'tinylog-impl', version: tinyLogVersion
 
     // JUnit test framework.
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: junitVersion
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2'
 
     // Mocking libraries
+    def mockitoVersion='4.3.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: mockitoVersion
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: mockitoVersion
-    testImplementation group: "com.github.tomakehurst", name:"wiremock-jre8", version: wireMockVersion
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.32.0'
 }
 
 jacocoTestReport {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,6 @@ group=com.truelayer
 archivesBaseName=truelayer-java
 version=0.7.2
 
-# Dependency properties
-retrofitVersion=2.9.0
-jacksonVersion=2.13.2
-tlSigningVersion=0.2.0
-tinyLogVersion=2.4.1
-apacheCommonsConfigurationVersion=2.7
-beanUtilsVersion=1.9.4
-
-# Test dependency properties
-junitVersion=5.8.2
-mockitoVersion=4.3.1
-wireMockVersion=2.32.0
-
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
 sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=0.7.2
+version=0.7.3
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/


### PR DESCRIPTION
# Description

1. Dependabot was not able to operate on versions declared on the gradle.properties file. So I changed that based on this comment
2. Bumping jackson-databind to fix [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation