### PR TITLE
[JSDK-72] Fixes spotless on recent java version and enable CI matrix on build jobs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '18'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8 ]
+        java: [ 8, 11, 15, 17 ]
     runs-on: ${{ matrix.os }}
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build:
-
     name: Build and tests
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get project version
         id: get_project_version
         run: |
-          PROJECT_VERSION=$(gradle properties -q | grep "version:" | awk '{print $2}')
+          PROJECT_VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
           echo "::set-output name=project_version::$PROJECT_VERSION"
       - name: Semantic versioning check
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
@@ -34,7 +34,7 @@ jobs:
         run: |
           PROJECT_VERSION=$(gradle properties -q | grep "version:" | awk '{print $2}')
           echo "::set-output name=project_version::$PROJECT_VERSION"
-      - name: Semver version check
+      - name: Semantic versioning check
         run: |
           if [[ "${{steps.get_project_version.outputs.project_version}}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
               echo "Project version ${{steps.get_project_version.outputs.project_version}} is valid"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
               echo "Project version ${{steps.get_project_version.outputs.project_version}} is not valid"; exit 1;
           fi
       - name: Lint
-        if: ${{ matrix.java }} >= 9
+        if: ${{ matrix.java }} = 8
         run: ./gradlew spotlessJavaCheck
       - name: Build
         run: ./gradlew build -x test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 15, 17 ]
+        java: [ 8, 11, 15, 17, 18 ]
     runs-on: ${{ matrix.os }}
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 14, 17 ]
+        java: [ 8 ]
     runs-on: ${{ matrix.os }}
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
               echo "Project version ${{steps.get_project_version.outputs.project_version}} is not valid"; exit 1;
           fi
       - name: Lint
+        if: ${{ matrix.java }} >= 9
         run: ./gradlew spotlessJavaCheck
       - name: Build
         run: ./gradlew build -x test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}
     steps:
-      - run: echo ${{ github.event.label.name}}
       - uses: actions/checkout@v3
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ jobs:
           cache: 'gradle'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Fix Gradle options on Java < 9
+        if: ${{ matrix.java < 9 }}
+        run: |
+          # removes jvm args
+          sed -ie s/org\.gradle\.jvmargs/_ignored/ gradle.properties
       - name: Get project version
         id: get_project_version
         run: |
@@ -41,10 +46,9 @@ jobs:
               echo "Project version ${{steps.get_project_version.outputs.project_version}} is not valid"; exit 1;
           fi
       - name: Lint
-        if: ${{ matrix.java == 8 }}
         run: ./gradlew spotlessJavaCheck
       - name: Build
-        run: ./gradlew build -x test -x spotlessJavaCheck
+        run: ./gradlew build -x test
       - name: Unit tests
         run: ./gradlew unit-tests
       - name: Integration tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}
     steps:
+      - run: echo ${{ github.event.label.name}}
       - uses: actions/checkout@v3
       - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
               echo "Project version ${{steps.get_project_version.outputs.project_version}} is not valid"; exit 1;
           fi
       - name: Lint
-        if: ${{ matrix.java }} = 8
+        if: ${{ matrix.java }} == 8
         run: ./gradlew spotlessJavaCheck
       - name: Build
         run: ./gradlew build -x test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ matrix.java == 8 }}
         run: ./gradlew spotlessJavaCheck
       - name: Build
-        run: ./gradlew build -x test
+        run: ./gradlew build -x test -x spotlessJavaCheck
       - name: Unit tests
         run: ./gradlew unit-tests
       - name: Integration tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+
     name: Build and tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        java: [ 8, 11, 14, 17 ]
+    runs-on: ${{ matrix.os }}
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}
     steps:
@@ -18,7 +24,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: ${{ matrix.java }}
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
               echo "Project version ${{steps.get_project_version.outputs.project_version}} is not valid"; exit 1;
           fi
       - name: Lint
-        if: ${{ matrix.java }} == 8
+        if: ${{ matrix.java == 8 }}
         run: ./gradlew spotlessJavaCheck
       - name: Build
         run: ./gradlew build -x test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       project_version: ${{ steps.get_project_version.outputs.project_version }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Setup JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Test coverage
-        run: ./gradlew test jacocoTestReport coveralls
+        run: ./gradlew unit-tests jacocoTestReport coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.coveralls_repo_token }}
           CI_BRANCH: ${{ inputs.branch }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '18'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Acceptance tests
+name: Coverage
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Test coverage
-        run: ./gradlew jacocoTestReport coveralls
+        run: ./gradlew test jacocoTestReport coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.coveralls_repo_token }}
           CI_BRANCH: ${{ inputs.branch }}

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [build, acceptance-tests]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '18'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '18'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -8,13 +8,6 @@ on:
       - '**'
 
 jobs:
-#  coverage:
-#    name: Test coverage analysis
-#    uses: ./.github/workflows/coverage.yml
-#    with:
-#      branch: ${{ github.head_ref }}
-#    secrets:
-#      coveralls_repo_token: ${{ secrets.COVERALLS_REPO_TOKEN }}
   build:
     name: Build and tests
     uses: ./.github/workflows/build.yml
@@ -36,7 +29,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Validate Gradle wrapper

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
     needs: [build, acceptance-tests]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           java-version: '17'

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -8,13 +8,13 @@ on:
       - '**'
 
 jobs:
-  coverage:
-    name: Test coverage analysis
-    uses: ./.github/workflows/coverage.yml
-    with:
-      branch: ${{ github.head_ref }}
-    secrets:
-      coveralls_repo_token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+#  coverage:
+#    name: Test coverage analysis
+#    uses: ./.github/workflows/coverage.yml
+#    with:
+#      branch: ${{ github.head_ref }}
+#    secrets:
+#      coveralls_repo_token: ${{ secrets.COVERALLS_REPO_TOKEN }}
   build:
     name: Build and tests
     uses: ./.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           echo "project_version_snapshot=${{needs.build.outputs.project_version}}-${GITHUB_REF##*/}-SNAPSHOT" >> $GITHUB_ENV
           echo "Snapshot project version created: ${{env.project_version_snapshot}}"
-      - name: Snaphost Semver version check
+      - name: Snapshot version check
         run: |
           SNAPSHOT_VERSION_REGEX="^([0-9]+)\.([0-9]+)\.([0-9]+)-${GITHUB_REF##*/}-SNAPSHOT$";
           if [[ "${{env.project_version_snapshot}}" =~ $SNAPSHOT_VERSION_REGEX ]]; then

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ CompletableFuture<ApiResponse<CreatePaymentResponse>> paymentResponse = client
     .createPayment(paymentRequest);
 
 // wait for the response
-ApiResponse<CreatePaymentResponse> payment = paymentResponse.get())
+ApiResponse<CreatePaymentResponse> payment = paymentResponse.get();
 ```
 
 ### Build a link to our hosted createPaymentResponse page

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ the builds will fail if not compliant.
 
 When developing on IntelliJ you can optionally install this [Spotless IntelliJ Gradle plugin](https://github.com/ragurney/spotless-intellij-gradle) as well.
 
+Due to an open issue with JDK16+, we had to specify some extra Jvm options in the [gradle.properties](gradle.properties) file.
+If you're building on JDK versions below 9, you'll have to remove/comment the `org.gradle.jvmargs` key in there.
+
 ## Contributing
 
 Contributions are always welcome!

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ project_developer=truelayer
 project_scm=scm:git:https://github.com/TrueLayer/truelayer-java.git
 
 # Fix for Spotless on recent Java versions. See: https://github.com/diffplug/spotless/issues/834
+# Remove this when building on JDK versions below 9
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,10 @@ project_license_url=https://raw.githubusercontent.com/TrueLayer/truelayer-java/m
 project_license_name=MIT License
 project_developer=truelayer
 project_scm=scm:git:https://github.com/TrueLayer/truelayer-java.git
+
+# Fix for Spotless on recent Java versions. See: https://github.com/diffplug/spotless/issues/834
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,10 +13,3 @@ project_license_url=https://raw.githubusercontent.com/TrueLayer/truelayer-java/m
 project_license_name=MIT License
 project_developer=truelayer
 project_scm=scm:git:https://github.com/TrueLayer/truelayer-java.git
-
-# Fix for Spotless on recent Java versions. See: https://github.com/diffplug/spotless/issues/834
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
# Description

- Adds gradle options to have spotless happy on JDK 16+. 
- Adds a matrix of JDK versions 8,11,15,17 when building the project, and updates the main one to 17
- A few doc fixes

This change won't trigger any release 

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation