### PR TITLE
[PAYG-920] remove auth flow from authorizing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=2.0.1
+version=2.0.2
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowAuthorizing.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowAuthorizing.java
@@ -1,5 +1,6 @@
 package com.truelayer.java.payments.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.truelayer.java.payments.entities.paymentdetail.Status;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -8,7 +9,11 @@ import lombok.Value;
 @EqualsAndHashCode(callSuper = false)
 public class AuthorizationFlowAuthorizing extends AuthorizationFlowResponse {
 
-    AuthorizationFlow authorizationFlow;
-
     Status status = Status.AUTHORIZING;
+
+    @JsonIgnore
+    @Override
+    public AuthorizationFlow getAuthorizationFlow() {
+        return authorizationFlow;
+    }
 }

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowAuthorizing.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowAuthorizing.java
@@ -1,6 +1,5 @@
 package com.truelayer.java.payments.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.truelayer.java.payments.entities.paymentdetail.Status;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -11,7 +10,6 @@ public class AuthorizationFlowAuthorizing extends AuthorizationFlowResponse {
 
     Status status = Status.AUTHORIZING;
 
-    @JsonIgnore
     @Override
     public AuthorizationFlow getAuthorizationFlow() {
         return authorizationFlow;

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowAuthorizing.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowAuthorizing.java
@@ -7,5 +7,8 @@ import lombok.Value;
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class AuthorizationFlowAuthorizing extends AuthorizationFlowResponse {
+
+    AuthorizationFlow authorizationFlow;
+
     Status status = Status.AUTHORIZING;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
@@ -25,8 +25,6 @@ public abstract class AuthorizationFlowResponse {
 
     protected Status status;
 
-    AuthorizationFlow authorizationFlow;
-
     @JsonIgnore
     public boolean isAuthorizing() {
         return this instanceof AuthorizationFlowAuthorizing;

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
@@ -18,12 +18,14 @@ import lombok.ToString;
     @JsonSubTypes.Type(value = AuthorizationFlowAuthorizing.class, name = "authorizing"),
     @JsonSubTypes.Type(value = AuthorizationFlowAuthorizationFailed.class, name = "failed")
 })
-@Getter
 @ToString
 @EqualsAndHashCode
 public abstract class AuthorizationFlowResponse {
 
+    @Getter
     protected Status status;
+
+    protected AuthorizationFlow authorizationFlow;
 
     @JsonIgnore
     public boolean isAuthorizing() {
@@ -51,16 +53,13 @@ public abstract class AuthorizationFlowResponse {
         return (AuthorizationFlowAuthorizationFailed) this;
     }
 
-    // @deprecated
-    // Only `Authorizating` responses have `AuthorizationFlow`.
-    // Use `asAuthorizing().getAuthorizationFlow()` instead.
-    @Deprecated
+    /**
+     * @deprecated Only {@link AuthorizationFlowAuthorizing Authorizing} responses have {@link AuthorizationFlow}. Use {@link #asAuthorizing()}.{@link AuthorizationFlowAuthorizing#getAuthorizationFlow() getAuthorizationFlow()} instead.
+     */
     @JsonIgnore
+    @Deprecated
     public AuthorizationFlow getAuthorizationFlow() {
-        if (!isAuthorizing()) {
-            throw new TrueLayerException(buildErrorMessage());
-        }
-        return asAuthorizing().getAuthorizationFlow();
+        return authorizationFlow;
     }
 
     private String buildErrorMessage() {

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
@@ -54,9 +54,8 @@ public abstract class AuthorizationFlowResponse {
     }
 
     /**
-     * @deprecated Only {@link AuthorizationFlowAuthorizing Authorizing} responses have {@link AuthorizationFlow}. Use {@link #asAuthorizing()}.{@link AuthorizationFlowAuthorizing#getAuthorizationFlow() getAuthorizationFlow()} instead.
+     * Deprecated: Only {@link AuthorizationFlowAuthorizing Authorizing} responses have {@link AuthorizationFlow}. Use {@link #asAuthorizing()}.{@link AuthorizationFlowAuthorizing#getAuthorizationFlow() getAuthorizationFlow()} instead.
      */
-    @JsonIgnore
     @Deprecated
     public AuthorizationFlow getAuthorizationFlow() {
         return authorizationFlow;

--- a/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
+++ b/src/main/java/com/truelayer/java/payments/entities/AuthorizationFlowResponse.java
@@ -51,6 +51,18 @@ public abstract class AuthorizationFlowResponse {
         return (AuthorizationFlowAuthorizationFailed) this;
     }
 
+    // @deprecated
+    // Only `Authorizating` responses have `AuthorizationFlow`.
+    // Use `asAuthorizing().getAuthorizationFlow()` instead.
+    @Deprecated
+    @JsonIgnore
+    public AuthorizationFlow getAuthorizationFlow() {
+        if (!isAuthorizing()) {
+            throw new TrueLayerException(buildErrorMessage());
+        }
+        return asAuthorizing().getAuthorizationFlow();
+    }
+
     private String buildErrorMessage() {
         return String.format("Response is of type %s.", this.getClass().getSimpleName());
     }

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -271,6 +271,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
 
         // follow the redirect uri and parse its Location HTTP response header
         URI redirectUri = authorizationFlowResponse
+                .asAuthorizing()
                 .getAuthorizationFlow()
                 .getActions()
                 .getNext()

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -186,6 +186,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
         // assert that the link returned is good to be browsed
         URI bankPage = startAuthorizationFlowResponse
                 .getData()
+                .asAuthorizing()
                 .getAuthorizationFlow()
                 .getActions()
                 .getNext()
@@ -233,6 +234,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
         // Call the mock payment api response to trigger the executed state on the payment just created
         URI redirectUri = startAuthorizationFlowResponse
                 .getData()
+                .asAuthorizing()
                 .getAuthorizationFlow()
                 .getActions()
                 .getNext()

--- a/src/test/java/com/truelayer/java/payments/entities/AuthorizationFlowResponseTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/AuthorizationFlowResponseTests.java
@@ -11,7 +11,7 @@ class AuthorizationFlowResponseTests {
     @Test
     @DisplayName("It should yield true if instance is of type PaymentAuthorizationFlowAuthorizing")
     public void shouldYieldTrueIfAuthorizing() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
 
         assertTrue(sut.isAuthorizing());
     }
@@ -19,7 +19,7 @@ class AuthorizationFlowResponseTests {
     @Test
     @DisplayName("It should convert to an instance of class PaymentAuthorizationFlowAuthorizing")
     public void shouldConvertToAuthorizing() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
 
         assertDoesNotThrow(sut::asAuthorizing);
     }
@@ -53,7 +53,7 @@ class AuthorizationFlowResponseTests {
     @Test
     @DisplayName("It should throw an error when converting to PaymentAuthorizationFlowAuthorizationFailed")
     public void shouldNotConvertToAuthorizationFailed() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
 
         Throwable thrown = assertThrows(TrueLayerException.class, sut::asAuthorizationFailed);
 

--- a/src/test/java/com/truelayer/java/payments/entities/AuthorizationFlowResponseTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/AuthorizationFlowResponseTests.java
@@ -51,6 +51,20 @@ class AuthorizationFlowResponseTests {
     }
 
     @Test
+    @DisplayName("It should get AuthorizationFlow for retro-compatibility")
+    public void shouldConvertToAuthorizationFailed2() {
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
+        AuthorizationFlowResponse sut2 = new AuthorizationFlowAuthorizationFailed("some stage", "some reason");
+
+        assertDoesNotThrow(sut.asAuthorizing()::getAuthorizationFlow);
+        assertDoesNotThrow(sut::getAuthorizationFlow);
+        assertEquals(sut.getAuthorizationFlow(), sut.asAuthorizing().getAuthorizationFlow());
+
+        assertThrows(TrueLayerException.class, sut2::getAuthorizationFlow);
+        assertThrows(TrueLayerException.class, sut2.asAuthorizationFailed()::getAuthorizationFlow);
+    }
+
+    @Test
     @DisplayName("It should throw an error when converting to PaymentAuthorizationFlowAuthorizationFailed")
     public void shouldNotConvertToAuthorizationFailed() {
         AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());

--- a/src/test/java/com/truelayer/java/payments/entities/AuthorizationFlowResponseTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/AuthorizationFlowResponseTests.java
@@ -11,7 +11,7 @@ class AuthorizationFlowResponseTests {
     @Test
     @DisplayName("It should yield true if instance is of type PaymentAuthorizationFlowAuthorizing")
     public void shouldYieldTrueIfAuthorizing() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
 
         assertTrue(sut.isAuthorizing());
     }
@@ -19,7 +19,7 @@ class AuthorizationFlowResponseTests {
     @Test
     @DisplayName("It should convert to an instance of class PaymentAuthorizationFlowAuthorizing")
     public void shouldConvertToAuthorizing() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
 
         assertDoesNotThrow(sut::asAuthorizing);
     }
@@ -51,23 +51,29 @@ class AuthorizationFlowResponseTests {
     }
 
     @Test
-    @DisplayName("It should get AuthorizationFlow for retro-compatibility")
-    public void shouldConvertToAuthorizationFailed2() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
-        AuthorizationFlowResponse sut2 = new AuthorizationFlowAuthorizationFailed("some stage", "some reason");
+    @DisplayName("It should get AuthorizationFlow from Authorizing for retro-compatibility")
+    public void shouldGetAuthorizationFlowFromAuthorizing() {
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
 
-        assertDoesNotThrow(sut.asAuthorizing()::getAuthorizationFlow);
         assertDoesNotThrow(sut::getAuthorizationFlow);
+        assertDoesNotThrow(sut.asAuthorizing()::getAuthorizationFlow);
         assertEquals(sut.getAuthorizationFlow(), sut.asAuthorizing().getAuthorizationFlow());
+    }
 
-        assertThrows(TrueLayerException.class, sut2::getAuthorizationFlow);
-        assertThrows(TrueLayerException.class, sut2.asAuthorizationFailed()::getAuthorizationFlow);
+    @Test
+    @DisplayName("It should get AuthorizationFlow from Failed for retro-compatibility")
+    public void shouldGetAuthorizationFlowFromFailed() {
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizationFailed("some stage", "some reason");
+
+        assertDoesNotThrow(sut::getAuthorizationFlow);
+        assertDoesNotThrow(sut.asAuthorizationFailed()::getAuthorizationFlow);
+        assertEquals(sut.getAuthorizationFlow(), sut.asAuthorizationFailed().getAuthorizationFlow());
     }
 
     @Test
     @DisplayName("It should throw an error when converting to PaymentAuthorizationFlowAuthorizationFailed")
     public void shouldNotConvertToAuthorizationFailed() {
-        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing(new AuthorizationFlow());
+        AuthorizationFlowResponse sut = new AuthorizationFlowAuthorizing();
 
         Throwable thrown = assertThrows(TrueLayerException.class, sut::asAuthorizationFailed);
 

--- a/src/test/resources/__files/payments/200.start_authorization_flow.failed.json
+++ b/src/test/resources/__files/payments/200.start_authorization_flow.failed.json
@@ -1,11 +1,4 @@
 {
-  "authorization_flow":{
-    "actions":{
-      "next":{
-        "type":"wait"
-      }
-    }
-  },
   "status":"failed",
   "failure_stage":"authorization_required",
   "failure_reason":"provider_rejected"


### PR DESCRIPTION
# Description

Payments API has removed the `authorization_flow` object from the `POST /payments/{id}/authorization-flow` [response](https://docs.truelayer.com/reference/start-payment-authorization-flow), when `status=failed`.
Thus we are deprecating `AuthorizationFlowResponse.getAuthorizationFlow()` in favor of `AuthorizationFlowResponse.asAuthorizing().getAuthorizationFlow()`.

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

This change is not a bug fix neither a new feature. This is a change whereas the usage of the usage of library gets closer to the usage of the API. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation