### PR TITLE
[JSDK-64] `metadata` object on payments and mandates DTOs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=2.0.1
+version=2.0.2
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/mandates/entities/CreateMandateRequest.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/CreateMandateRequest.java
@@ -3,6 +3,7 @@ package com.truelayer.java.mandates.entities;
 import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.entities.User;
 import com.truelayer.java.mandates.entities.mandate.Mandate;
+import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,11 +15,13 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class CreateMandateRequest {
 
-    Mandate mandate;
+    private Mandate mandate;
 
-    CurrencyCode currency;
+    private CurrencyCode currency;
 
-    User user;
+    private User user;
 
-    Constraints constraints;
+    private Constraints constraints;
+
+    private Map<String, String> metadata;
 }

--- a/src/main/java/com/truelayer/java/mandates/entities/mandatedetail/MandateDetail.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/mandatedetail/MandateDetail.java
@@ -8,6 +8,7 @@ import com.truelayer.java.entities.User;
 import com.truelayer.java.entities.beneficiary.Beneficiary;
 import com.truelayer.java.mandates.entities.Constraints;
 import java.time.ZonedDateTime;
+import java.util.Map;
 import lombok.*;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "status", defaultImpl = AuthorizationRequiredMandateDetail.class)
@@ -31,6 +32,8 @@ public abstract class MandateDetail {
     private ZonedDateTime createdAt;
 
     private Constraints constraints;
+
+    private Map<String, String> metadata;
 
     public abstract Status getStatus();
 

--- a/src/main/java/com/truelayer/java/payments/entities/CreatePaymentRequest.java
+++ b/src/main/java/com/truelayer/java/payments/entities/CreatePaymentRequest.java
@@ -3,6 +3,7 @@ package com.truelayer.java.payments.entities;
 import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.entities.User;
 import com.truelayer.java.payments.entities.paymentmethod.PaymentMethod;
+import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -20,4 +21,6 @@ public class CreatePaymentRequest {
     private PaymentMethod paymentMethod;
 
     private User user;
+
+    private Map<String, String> metadata;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetail.java
@@ -7,6 +7,7 @@ import com.truelayer.java.TrueLayerException;
 import com.truelayer.java.entities.User;
 import com.truelayer.java.payments.entities.paymentmethod.PaymentMethod;
 import java.time.ZonedDateTime;
+import java.util.Map;
 import lombok.*;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "status", defaultImpl = AuthorizationRequiredPaymentDetail.class)
@@ -31,6 +32,8 @@ public abstract class PaymentDetail {
     private PaymentMethod paymentMethod;
 
     private ZonedDateTime createdAt;
+
+    private Map<String, String> metadata;
 
     public abstract Status getStatus();
 

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -24,6 +24,7 @@ import com.truelayer.java.mandates.entities.mandatedetail.MandateDetail;
 import com.truelayer.java.payments.entities.*;
 import com.truelayer.java.payments.entities.paymentmethod.PaymentMethod;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.SneakyThrows;
@@ -200,7 +201,6 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                                     .sortCode("140662")
                                     .build())
                             .accountHolderName("Andrea Java SDK")
-                            .reference("a reference")
                             .build())
                     .build();
         } else {
@@ -212,7 +212,6 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                                     .sortCode("140662")
                                     .build())
                             .accountHolderName("Andrea Java SDK")
-                            .reference("a reference")
                             .build())
                     .build();
         }
@@ -244,6 +243,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                                 .build())
                         .maximumIndividualAmount(1000)
                         .build())
+                .metadata(Collections.singletonMap("a_custom_key", "a-custom-value"))
                 .build();
     }
 

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -284,6 +284,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                         .name("Andrea Di Lisio")
                         .email("andrea@truelayer.com")
                         .build())
+                .metadata(Collections.singletonMap("a_custom_key", "a-custom-value"))
                 .build();
     }
 

--- a/src/test/resources/__files/mandates/200.get_mandate_by_id.authorization_required.json
+++ b/src/test/resources/__files/mandates/200.get_mandate_by_id.authorization_required.json
@@ -28,5 +28,8 @@
         "period_alignment": "consent"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/mandates/200.get_mandate_by_id.authorized.json
+++ b/src/test/resources/__files/mandates/200.get_mandate_by_id.authorized.json
@@ -46,5 +46,8 @@
         "period_alignment": "consent"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/mandates/200.get_mandate_by_id.authorizing.json
+++ b/src/test/resources/__files/mandates/200.get_mandate_by_id.authorizing.json
@@ -45,5 +45,8 @@
         "period_alignment": "consent"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/mandates/200.get_mandate_by_id.failed.json
+++ b/src/test/resources/__files/mandates/200.get_mandate_by_id.failed.json
@@ -31,5 +31,8 @@
         "period_alignment": "consent"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/mandates/200.get_mandate_by_id.revoked.json
+++ b/src/test/resources/__files/mandates/200.get_mandate_by_id.revoked.json
@@ -31,5 +31,8 @@
         "period_alignment": "consent"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/mandates/200.list_mandates.json
+++ b/src/test/resources/__files/mandates/200.list_mandates.json
@@ -29,6 +29,9 @@
             "period_alignment": "consent"
           }
         }
+      },
+      "metadata": {
+        "a_custom_key": "a-value"
       }
     },
     {

--- a/src/test/resources/__files/payments/200.get_payment_by_id.authorization_required.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.authorization_required.json
@@ -17,5 +17,8 @@
     }
   },
   "created_at":"2022-01-17T17:13:18.214924Z",
-  "status":"authorization_required"
+  "status":"authorization_required",
+  "metadata": {
+    "a_custom_key": "a-value"
+  }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.authorized.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.authorized.json
@@ -47,5 +47,8 @@
         "return_uri":"http://localhost"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.authorizing.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.authorizing.json
@@ -46,5 +46,8 @@
         "status":"not_supported"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.executed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.executed.json
@@ -47,5 +47,8 @@
     ],
     "account_holder_name":"John Doe"
   },
-  "executed_at":"2022-01-17T17:13:18.214924Z"
+  "executed_at":"2022-01-17T17:13:18.214924Z",
+  "metadata": {
+    "a_custom_key": "a-value"
+  }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.failed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.failed.json
@@ -39,5 +39,8 @@
   "status":"failed",
   "failed_at":"2022-01-17T17:13:18.214924Z",
   "failure_stage":"authorization_required",
-  "failure_reason":"failed"
+  "failure_reason":"failed",
+  "metadata": {
+    "a_custom_key": "a-value"
+  }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.settled.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.settled.json
@@ -63,5 +63,8 @@
         "status":"not_supported"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.unknown_response_field.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.unknown_response_field.json
@@ -59,5 +59,8 @@
         "status":"not_supported"
       }
     }
+  },
+  "metadata": {
+    "a_custom_key": "a-value"
   }
 }


### PR DESCRIPTION
# Description

As per title, adding the `metadata` object on payment and mandates DTOs. 
I'm deliberately not setting any size validation on the map, problem details errors will provide the required context in case of failures. Moreover, we don't have anything to do if the same validation will change in future on our Payments v3 API


## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation