### PR TITLE
[JSDK-80] Confirmation of Funds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ to propose new features.
 
 ## Submit changes
 
-In order to submit changes to the TrueLayer Java project the follwoing steps are required: 
+In order to submit changes to the TrueLayer Java project the following steps are required: 
 
 1. Fork the repo and create your branch from `main`.
 2. Make sure to add proper tests in case of code changes. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=2.1.1
+version=2.2.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
+++ b/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
@@ -81,7 +81,7 @@ public interface IMandatesApi {
     CompletableFuture<ApiResponse<Void>> revokeMandate(@Path("id") String mandateId);
 
     /**
-     * Revoke mandate
+     * Get Confirmation Of Funds
      * @param mandateId the id of the mandate
      * @param amount_in_minor the amount to be confirmed present in the bank account
      * @param currency the currency of the mandate

--- a/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
+++ b/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
@@ -3,6 +3,7 @@ package com.truelayer.java.mandates;
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.mandates.entities.CreateMandateRequest;
 import com.truelayer.java.mandates.entities.CreateMandateResponse;
+import com.truelayer.java.mandates.entities.GetConfirmationOfFundsResponse;
 import com.truelayer.java.mandates.entities.ListMandatesResponse;
 import com.truelayer.java.mandates.entities.mandatedetail.MandateDetail;
 import com.truelayer.java.payments.entities.AuthorizationFlowResponse;
@@ -78,4 +79,18 @@ public interface IMandatesApi {
      */
     @POST("/mandates/{id}/revoke")
     CompletableFuture<ApiResponse<Void>> revokeMandate(@Path("id") String mandateId);
+
+    /**
+     * Revoke mandate
+     * @param mandateId the id of the mandate
+     * @param amount_in_minor the amount to be confirmed present in the bank account
+     * @param currency the currency of the mandate
+     * @return a boolean representing funds availability and the time this was checked
+     * @see <a href="https://docs.truelayer.com/reference/confirm-mandate-funds"><i>Funds Confirmation</i> API reference</a>
+     */
+    @GET("/mandates/{id}/funds?amount_in_minor={amount_in_minor}&currency={currency}")
+    CompletableFuture<ApiResponse<GetConfirmationOfFundsResponse>> getConfirmationOfFunds(
+            @Path("id") String mandateId,
+            @Path("amount_in_minor") String amount_in_minor,
+            @Path("currency") String currency);
 }

--- a/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
+++ b/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
@@ -88,7 +88,7 @@ public interface IMandatesApi {
      * @return a boolean representing funds availability and the time this was checked
      * @see <a href="https://docs.truelayer.com/reference/confirm-mandate-funds"><i>Funds Confirmation</i> API reference</a>
      */
-    @GET("/mandates/{id}/funds?amount_in_minor={amount_in_minor}&currency={currency}")
+    @GET("/mandates/{id}/funds?")
     CompletableFuture<ApiResponse<GetConfirmationOfFundsResponse>> getConfirmationOfFunds(
             @Path("id") String mandateId,
             @Query("amount_in_minor") String amount_in_minor,

--- a/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
+++ b/src/main/java/com/truelayer/java/mandates/IMandatesApi.java
@@ -91,6 +91,6 @@ public interface IMandatesApi {
     @GET("/mandates/{id}/funds?amount_in_minor={amount_in_minor}&currency={currency}")
     CompletableFuture<ApiResponse<GetConfirmationOfFundsResponse>> getConfirmationOfFunds(
             @Path("id") String mandateId,
-            @Path("amount_in_minor") String amount_in_minor,
-            @Path("currency") String currency);
+            @Query("amount_in_minor") String amount_in_minor,
+            @Query("currency") String currency);
 }

--- a/src/main/java/com/truelayer/java/mandates/IMandatesHandler.java
+++ b/src/main/java/com/truelayer/java/mandates/IMandatesHandler.java
@@ -1,16 +1,12 @@
 package com.truelayer.java.mandates;
 
 import com.truelayer.java.http.entities.ApiResponse;
-import com.truelayer.java.mandates.entities.CreateMandateRequest;
-import com.truelayer.java.mandates.entities.CreateMandateResponse;
-import com.truelayer.java.mandates.entities.ListMandatesQuery;
-import com.truelayer.java.mandates.entities.ListMandatesResponse;
+import com.truelayer.java.mandates.entities.*;
 import com.truelayer.java.mandates.entities.mandatedetail.MandateDetail;
 import com.truelayer.java.payments.entities.AuthorizationFlowResponse;
 import com.truelayer.java.payments.entities.StartAuthorizationFlowRequest;
 import com.truelayer.java.payments.entities.SubmitProviderSelectionRequest;
 import java.util.concurrent.CompletableFuture;
-import retrofit2.http.*;
 
 /**
  * Provides /mandates API integration without the burden of Retrofit's annotation
@@ -32,4 +28,7 @@ public interface IMandatesHandler {
     CompletableFuture<ApiResponse<MandateDetail>> getMandate(String mandateId);
 
     CompletableFuture<ApiResponse<Void>> revokeMandate(String mandateId);
+
+    CompletableFuture<ApiResponse<GetConfirmationOfFundsResponse>> getConfirmationOfFunds(
+            String mandateId, String amount, String currency);
 }

--- a/src/main/java/com/truelayer/java/mandates/MandatesHandler.java
+++ b/src/main/java/com/truelayer/java/mandates/MandatesHandler.java
@@ -3,6 +3,7 @@ package com.truelayer.java.mandates;
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.mandates.entities.CreateMandateRequest;
 import com.truelayer.java.mandates.entities.CreateMandateResponse;
+import com.truelayer.java.mandates.entities.GetConfirmationOfFundsResponse;
 import com.truelayer.java.mandates.entities.ListMandatesQuery;
 import com.truelayer.java.mandates.entities.ListMandatesResponse;
 import com.truelayer.java.mandates.entities.mandatedetail.MandateDetail;
@@ -51,5 +52,11 @@ public class MandatesHandler implements IMandatesHandler {
     @Override
     public CompletableFuture<ApiResponse<Void>> revokeMandate(String mandateId) {
         return mandatesApi.revokeMandate(mandateId);
+    }
+
+    @Override
+    public CompletableFuture<ApiResponse<GetConfirmationOfFundsResponse>> getConfirmationOfFunds(
+            String mandateId, String amount_in_minor, String currency) {
+        return mandatesApi.getConfirmationOfFunds(mandateId, amount_in_minor, currency);
     }
 }

--- a/src/main/java/com/truelayer/java/mandates/entities/GetConfirmationOfFundsResponse.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/GetConfirmationOfFundsResponse.java
@@ -1,0 +1,10 @@
+package com.truelayer.java.mandates.entities;
+
+import lombok.Value;
+
+@Value
+public class GetConfirmationOfFundsResponse {
+    Boolean confirmed;
+
+    String confirmed_at;
+}

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -129,8 +129,9 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
         // authorize the created mandate without explicit user interaction
         authorizeMandate(startAuthorizationFlowResponse.getData());
 
-        ApiResponse<GetConfirmationOfFundsResponse> getConfirmationOfFundsResponseApiResponse =
-                tlClient.mandates().getConfirmationOfFunds(createMandateResponse.getData().getId(), "1", "GBP").get();
+        ApiResponse<GetConfirmationOfFundsResponse> getConfirmationOfFundsResponseApiResponse = tlClient.mandates()
+                .getConfirmationOfFunds(createMandateResponse.getData().getId(), "1", "GBP")
+                .get();
 
         assertNotError(getConfirmationOfFundsResponseApiResponse);
     }

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -145,6 +145,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
 
         assertNotError(getMandateResponse);
 
+        // finally make a confirmation of funds request for 1 penny
         ApiResponse<GetConfirmationOfFundsResponse> getConfirmationOfFundsResponseApiResponse = tlClient.mandates()
                 .getConfirmationOfFunds(getMandateResponse.getData().getId(), "1", "GBP")
                 .get();

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -4,8 +4,7 @@ import static com.truelayer.java.TestUtils.*;
 import static com.truelayer.java.mandates.entities.Constraints.PeriodicLimits.Limit.PeriodAlignment.CALENDAR;
 import static com.truelayer.java.mandates.entities.mandate.Mandate.Type.COMMERCIAL;
 import static com.truelayer.java.mandates.entities.mandate.Mandate.Type.SWEEPING;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.entities.User;
@@ -151,6 +150,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .get();
 
         assertNotError(getConfirmationOfFundsResponseApiResponse);
+        assertEquals(true, getConfirmationOfFundsResponseApiResponse.getData().getConfirmed());
     }
 
     @Test

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -121,16 +121,32 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .get();
         assertNotError(createMandateResponse);
 
-        // we must authorize the mandate before revoking it
-        ApiResponse<AuthorizationFlowResponse> startAuthorizationFlowResponse =
-                startAuthFlowForMandate(createMandateResponse.getData().getId());
+        // start auth flow
+        StartAuthorizationFlowRequest startAuthorizationFlowRequest = StartAuthorizationFlowRequest.builder()
+                .withProviderSelection()
+                .redirect(StartAuthorizationFlowRequest.Redirect.builder()
+                        .returnUri(URI.create(RETURN_URI))
+                        .build())
+                .build();
+
+        ApiResponse<AuthorizationFlowResponse> startAuthorizationFlowResponse = tlClient.mandates()
+                .startAuthorizationFlow(createMandateResponse.getData().getId(), startAuthorizationFlowRequest)
+                .get();
+
         assertNotError(startAuthorizationFlowResponse);
 
         // authorize the created mandate without explicit user interaction
         authorizeMandate(startAuthorizationFlowResponse.getData());
 
+        // get mandate by id
+        ApiResponse<MandateDetail> getMandateResponse = tlClient.mandates()
+                .getMandate(createMandateResponse.getData().getId())
+                .get();
+
+        assertNotError(getMandateResponse);
+
         ApiResponse<GetConfirmationOfFundsResponse> getConfirmationOfFundsResponseApiResponse = tlClient.mandates()
-                .getConfirmationOfFunds(createMandateResponse.getData().getId(), "1", "GBP")
+                .getConfirmationOfFunds(getMandateResponse.getData().getId(), "1", "GBP")
                 .get();
 
         assertNotError(getConfirmationOfFundsResponseApiResponse);

--- a/src/test/java/com/truelayer/java/integration/MandatesIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/MandatesIntegrationTests.java
@@ -220,8 +220,9 @@ public class MandatesIntegrationTests extends IntegrationTests {
                 .bodyFile(jsonResponseFile)
                 .build();
 
-        ApiResponse<GetConfirmationOfFundsResponse> response =
-                tlClient.mandates().getConfirmationOfFunds(A_MANDATE_ID, "1", "gbp").get();
+        ApiResponse<GetConfirmationOfFundsResponse> response = tlClient.mandates()
+                .getConfirmationOfFunds(A_MANDATE_ID, "1", "gbp")
+                .get();
 
         GetConfirmationOfFundsResponse expected =
                 deserializeJsonFileTo(jsonResponseFile, GetConfirmationOfFundsResponse.class);

--- a/src/test/java/com/truelayer/java/integration/MandatesIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/MandatesIntegrationTests.java
@@ -12,6 +12,7 @@ import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.http.entities.ProblemDetails;
 import com.truelayer.java.mandates.entities.CreateMandateRequest;
 import com.truelayer.java.mandates.entities.CreateMandateResponse;
+import com.truelayer.java.mandates.entities.GetConfirmationOfFundsResponse;
 import com.truelayer.java.mandates.entities.ListMandatesResponse;
 import com.truelayer.java.mandates.entities.mandatedetail.MandateDetail;
 import com.truelayer.java.mandates.entities.mandatedetail.Status;
@@ -197,6 +198,36 @@ public class MandatesIntegrationTests extends IntegrationTests {
                 tlClient.mandates().revokeMandate(A_MANDATE_ID).get();
 
         assertNotError(response);
+    }
+
+    @SneakyThrows
+    @Test
+    @DisplayName("It should get funds")
+    public void shouldGetFundsConfirmation() {
+        String jsonResponseFile = "mandates/200.get_confirmation_of_funds.json";
+        RequestStub.New()
+                .method("post")
+                .path(urlPathEqualTo("/connect/token"))
+                .status(200)
+                .bodyFile("auth/200.access_token.json")
+                .build();
+
+        RequestStub.New()
+                .method("get")
+                .path(urlPathEqualTo("/mandates/" + A_MANDATE_ID + "/funds"))
+                .withAuthorization()
+                .status(200)
+                .bodyFile(jsonResponseFile)
+                .build();
+
+        ApiResponse<GetConfirmationOfFundsResponse> response =
+                tlClient.mandates().getConfirmationOfFunds(A_MANDATE_ID, "1", "gbp").get();
+
+        GetConfirmationOfFundsResponse expected =
+                deserializeJsonFileTo(jsonResponseFile, GetConfirmationOfFundsResponse.class);
+
+        assertNotError(response);
+        assertEquals(expected.getConfirmed(), response.getData().getConfirmed());
     }
 
     @SneakyThrows

--- a/src/test/java/com/truelayer/java/mandates/MandatesHandlerTests.java
+++ b/src/test/java/com/truelayer/java/mandates/MandatesHandlerTests.java
@@ -16,6 +16,8 @@ class MandatesHandlerTests {
     private static final String A_CURSOR = "a-cursor";
     private static final String A_USER_ID = "a-user-id";
     private static final int A_LIMIT = 15;
+    private static final String AN_AMOUNT_IN_MINOR = "10";
+    private static final String A_CURRENCY = "GBP";
 
     @Test
     @DisplayName("It should call the create mandate endpoint")
@@ -102,5 +104,16 @@ class MandatesHandlerTests {
         sut.revokeMandate(A_MANDATE_ID);
 
         verify(mandatesApi, times(1)).revokeMandate(A_MANDATE_ID);
+    }
+
+    @Test
+    @DisplayName("It should call the CoF endpoint")
+    public void shouldCallCOFEndpoint() {
+        IMandatesApi mandatesApi = Mockito.mock(IMandatesApi.class);
+        MandatesHandler sut = new MandatesHandler(mandatesApi);
+
+        sut.getConfirmationOfFunds(A_MANDATE_ID, AN_AMOUNT_IN_MINOR, A_CURRENCY);
+
+        verify(mandatesApi, times(1)).getConfirmationOfFunds(A_MANDATE_ID, AN_AMOUNT_IN_MINOR, A_CURRENCY);
     }
 }

--- a/src/test/resources/__files/mandates/200.get_confirmation_of_funds.json
+++ b/src/test/resources/__files/mandates/200.get_confirmation_of_funds.json
@@ -1,0 +1,4 @@
+{
+  "confirmed": true,
+  "confirmed_at": "2022-08-25T15:56:09.415Z"
+}


### PR DESCRIPTION
# Description

This adds support for performing a Confirmation of Funds call on a mandate. The call requires requires a mandate id, an amount and a currency and returns a boolean and a time the check was performed. 

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation