### PR TITLE
[PAYG-1133] Add extra fields to user object

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=2.2.1
+version=2.2.2
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/entities/Address.java
+++ b/src/main/java/com/truelayer/java/entities/Address.java
@@ -1,0 +1,28 @@
+package com.truelayer.java.entities;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import java.util.Optional;
+import lombok.*;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class Address {
+    private String addressLine1;
+
+    private String addressLine2;
+
+    private String city;
+
+    private String state;
+
+    private String zip;
+
+    private String countryCode;
+
+    @JsonGetter
+    private Optional<String> getAddressLine2() {
+        return Optional.ofNullable(addressLine2);
+    }
+}

--- a/src/main/java/com/truelayer/java/entities/User.java
+++ b/src/main/java/com/truelayer/java/entities/User.java
@@ -1,6 +1,8 @@
 package com.truelayer.java.entities;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import java.time.LocalDate;
 import java.util.Optional;
 import lombok.*;
 
@@ -17,6 +19,11 @@ public class User {
 
     private String phone;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate dateOfBirth;
+
+    private Address address;
+
     @JsonGetter
     private Optional<String> getEmail() {
         return Optional.ofNullable(email);
@@ -25,5 +32,15 @@ public class User {
     @JsonGetter
     private Optional<String> getPhone() {
         return Optional.ofNullable(phone);
+    }
+
+    @JsonGetter
+    private Optional<LocalDate> getDateOfBirth() {
+        return Optional.ofNullable(dateOfBirth);
+    }
+
+    @JsonGetter
+    private Optional<Address> getAddress() {
+        return Optional.ofNullable(address);
     }
 }

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.truelayer.java.commonapi.entities.SubmitPaymentReturnParametersRequest;
 import com.truelayer.java.commonapi.entities.SubmitPaymentReturnParametersResponse;
+import com.truelayer.java.entities.Address;
 import com.truelayer.java.entities.ProviderFilter;
 import com.truelayer.java.entities.Remitter;
 import com.truelayer.java.entities.User;
@@ -21,6 +22,7 @@ import com.truelayer.java.payments.entities.paymentdetail.PaymentDetail;
 import com.truelayer.java.payments.entities.paymentmethod.PaymentMethod;
 import com.truelayer.java.payments.entities.providerselection.PreselectedProviderSelection;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.UUID;
 import lombok.SneakyThrows;
@@ -287,6 +289,14 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 .user(User.builder()
                         .name("Andrea Di Lisio")
                         .email("andrea@truelayer.com")
+                        .dateOfBirth(LocalDate.now())
+                        .address(Address.builder()
+                                .addressLine1("1 Hardwick Street")
+                                .city("London")
+                                .state("Greater London")
+                                .zip("EC1R 4RB")
+                                .countryCode("GB")
+                                .build())
                         .build())
                 .metadata(Collections.singletonMap("a_custom_key", "a-custom-value"))
                 .build();

--- a/src/test/resources/__files/payments/200.get_payment_by_id.authorization_required.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.authorization_required.json
@@ -6,7 +6,16 @@
   "user":{
     "id":"ac459f9f-37df-4cd7-ada5-***",
     "name":"Andrea Di Lisio",
-    "email":"andrea@truelayer.com"
+    "email":"andrea@truelayer.com",
+    "date_of_birth": "1990-01-31",
+    "address": {
+      "address_line1": "1 Hardwick Street",
+      "address_line2": "3rd Floor",
+      "city": "London",
+      "state": "Greater London",
+      "zip": "EC1R 4RB",
+      "country_code": "GB"
+    }
   },
   "payment_method":{
     "type":"bank_transfer",


### PR DESCRIPTION
# Description

Adding the `date_of_birth` and `address` fields to the `user` object.

[Fixes # (PAYG-1133)]

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation