### PR TITLE
feat: [PAYG-1169] add status to create payment response

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=2.3.0
+version=2.4.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponse.java
+++ b/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponse.java
@@ -1,13 +1,74 @@
 package com.truelayer.java.payments.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.truelayer.java.TrueLayerException;
 import com.truelayer.java.entities.User;
-import lombok.Value;
+import com.truelayer.java.payments.entities.paymentdetail.Status;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@Value
-public class CreatePaymentResponse {
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "status")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = CreatePaymentResponseAuthorizationRequired.class, name = "authorization_required"),
+    @JsonSubTypes.Type(value = CreatePaymentResponseAuthorized.class, name = "authorized"),
+    @JsonSubTypes.Type(value = CreatePaymentResponseFailed.class, name = "failed")
+})
+@ToString
+@EqualsAndHashCode
+@Getter
+public abstract class CreatePaymentResponse {
+    @Getter
+    protected Status status;
+
     String id;
 
     User user;
 
     String resourceToken;
+
+    @JsonIgnore
+    public boolean isAuthorizationRequired() {
+        return this instanceof CreatePaymentResponseAuthorizationRequired;
+    }
+
+    @JsonIgnore
+    public boolean isAuthorized() {
+        return this instanceof CreatePaymentResponseAuthorized;
+    }
+
+    @JsonIgnore
+    public boolean isFailed() {
+        return this instanceof CreatePaymentResponseFailed;
+    }
+
+    @JsonIgnore
+    public CreatePaymentResponseAuthorizationRequired asAuthorizationRequired() {
+        if (!isAuthorizationRequired()) {
+            throw new TrueLayerException(buildErrorMessage());
+        }
+        return (CreatePaymentResponseAuthorizationRequired) this;
+    }
+
+    @JsonIgnore
+    public CreatePaymentResponseAuthorized asAuthorized() {
+        if (!isAuthorized()) {
+            throw new TrueLayerException(buildErrorMessage());
+        }
+        return (CreatePaymentResponseAuthorized) this;
+    }
+
+    @JsonIgnore
+    public CreatePaymentResponseFailed asFailed() {
+        if (!isFailed()) {
+            throw new TrueLayerException(buildErrorMessage());
+        }
+        return (CreatePaymentResponseFailed) this;
+    }
+
+    private String buildErrorMessage() {
+        return String.format("Response is of type %s.", this.getClass().getSimpleName());
+    }
 }

--- a/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponseAuthorizationRequired.java
+++ b/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponseAuthorizationRequired.java
@@ -1,0 +1,11 @@
+package com.truelayer.java.payments.entities;
+
+import com.truelayer.java.payments.entities.paymentdetail.Status;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class CreatePaymentResponseAuthorizationRequired extends CreatePaymentResponse {
+    Status status = Status.AUTHORIZATION_REQUIRED;
+}

--- a/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponseAuthorized.java
+++ b/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponseAuthorized.java
@@ -1,0 +1,11 @@
+package com.truelayer.java.payments.entities;
+
+import com.truelayer.java.payments.entities.paymentdetail.Status;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class CreatePaymentResponseAuthorized extends CreatePaymentResponse {
+    Status status = Status.AUTHORIZED;
+}

--- a/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponseFailed.java
+++ b/src/main/java/com/truelayer/java/payments/entities/CreatePaymentResponseFailed.java
@@ -1,0 +1,15 @@
+package com.truelayer.java.payments.entities;
+
+import com.truelayer.java.payments.entities.paymentdetail.Status;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class CreatePaymentResponseFailed extends CreatePaymentResponse {
+    Status status = Status.FAILED;
+
+    String failureStage;
+
+    String failureReason;
+}

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -56,6 +56,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // get it by id
         ApiResponse<PaymentDetail> getPaymentByIdResponse = tlClient.payments()
@@ -88,6 +89,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // get it by id
         ApiResponse<PaymentDetail> getPaymentByIdResponse = tlClient.payments()
@@ -108,6 +110,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // open it in HPP
         URI link = tlClient.hpp()
@@ -130,6 +133,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // start the auth flow
         StartAuthorizationFlowRequest startAuthorizationFlowRequest = StartAuthorizationFlowRequest.builder()
@@ -175,6 +179,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // start the auth flow
         StartAuthorizationFlowRequest startAuthorizationFlowRequest = StartAuthorizationFlowRequest.builder()
@@ -279,6 +284,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // start the auth flow
         StartAuthorizationFlowRequest startAuthorizationFlowRequest = StartAuthorizationFlowRequest.builder()
@@ -326,6 +332,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 tlClient.payments().createPayment(paymentRequest).get();
 
         assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // start the auth flow
         StartAuthorizationFlowRequest startAuthorizationFlowRequest = StartAuthorizationFlowRequest.builder()

--- a/src/test/java/com/truelayer/java/integration/PaymentsIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/PaymentsIntegrationTests.java
@@ -22,11 +22,12 @@ public class PaymentsIntegrationTests extends IntegrationTests {
 
     public static final String A_PAYMENT_ID = "a-payment-id";
 
-    @Test
     @DisplayName("It should create and return a payment")
+    @ParameterizedTest(name = "of a payment with create response status {0}")
+    @ValueSource(strings = {"AUTHORIZATION_REQUIRED", "AUTHORIZED", "FAILED"})
     @SneakyThrows
-    public void shouldCreateAndReturnAPaymentMerchantAccount() {
-        String jsonResponseFile = "payments/201.create_payment.json";
+    public void shouldCreateAndReturnAPaymentMerchantAccount(Status expectedStatus) {
+        String jsonResponseFile = "payments/201.create_payment." + expectedStatus.getStatus() + ".json";
         RequestStub.New()
                 .method("post")
                 .path(urlPathEqualTo("/connect/token"))
@@ -48,6 +49,7 @@ public class PaymentsIntegrationTests extends IntegrationTests {
 
         assertNotError(response);
         CreatePaymentResponse expected = TestUtils.deserializeJsonFileTo(jsonResponseFile, CreatePaymentResponse.class);
+        assertEquals(expectedStatus, response.getData().getStatus());
         assertEquals(expected, response.getData());
     }
 

--- a/src/test/java/com/truelayer/java/integration/cache/DefaultAccessTokenCacheTests.java
+++ b/src/test/java/com/truelayer/java/integration/cache/DefaultAccessTokenCacheTests.java
@@ -31,7 +31,7 @@ public class DefaultAccessTokenCacheTests extends IntegrationTests {
                 .withAuthorization()
                 .withSignature()
                 .status(201)
-                .bodyFile("payments/201.create_payment.json")
+                .bodyFile("payments/201.create_payment.authorization_required.json")
                 .build();
         CreatePaymentRequest paymentRequest = CreatePaymentRequest.builder().build();
 
@@ -91,7 +91,7 @@ public class DefaultAccessTokenCacheTests extends IntegrationTests {
                 .withAuthorization()
                 .withSignature()
                 .status(201)
-                .bodyFile("payments/201.create_payment.json")
+                .bodyFile("payments/201.create_payment.authorization_required.json")
                 .build();
         AccessToken expectedImmediateExpirationToken =
                 deserializeJsonFileTo(accessTokenImmediateExpirationJsonFile, AccessToken.class);

--- a/src/test/java/com/truelayer/java/integration/cache/NoAccessTokenCacheTests.java
+++ b/src/test/java/com/truelayer/java/integration/cache/NoAccessTokenCacheTests.java
@@ -51,7 +51,7 @@ public class NoAccessTokenCacheTests extends IntegrationTests {
                 .withAuthorization()
                 .withSignature()
                 .status(201)
-                .bodyFile("payments/201.create_payment.json")
+                .bodyFile("payments/201.create_payment.authorization_required.json")
                 .build();
         CreatePaymentRequest paymentRequest = CreatePaymentRequest.builder().build();
 

--- a/src/test/java/com/truelayer/java/payments/entities/CreatePaymentResponseTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/CreatePaymentResponseTests.java
@@ -1,0 +1,88 @@
+package com.truelayer.java.payments.entities;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.truelayer.java.TrueLayerException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreatePaymentResponseTests {
+
+    @Test
+    @DisplayName("It should yield true if instance is of type CreatePaymentResponseAuthorizationRequired")
+    public void shouldYieldTrueIfAuthorizationRequired() {
+        CreatePaymentResponse sut = new CreatePaymentResponseAuthorizationRequired();
+
+        assertTrue(sut.isAuthorizationRequired());
+    }
+
+    @Test
+    @DisplayName("It should convert to an instance of class CreatePaymentResponseAuthorizationRequired")
+    public void shouldConvertToAuthorizationRequired() {
+        CreatePaymentResponse sut = new CreatePaymentResponseAuthorizationRequired();
+
+        assertDoesNotThrow(sut::asAuthorizationRequired);
+    }
+
+    @Test
+    @DisplayName("It should throw an error when converting to CreatePaymentResponseAuthorizationRequired")
+    public void shouldNotConvertToAuthorizationRequired() {
+        CreatePaymentResponse sut = new CreatePaymentResponseFailed(null, null);
+
+        Throwable thrown = assertThrows(TrueLayerException.class, sut::asAuthorizationRequired);
+
+        assertEquals(String.format("Response is of type %s.", sut.getClass().getSimpleName()), thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("It should yield true if instance is of type CreatePaymentResponseAuthorized")
+    public void shouldYieldTrueIfAuthorized() {
+        CreatePaymentResponse sut = new CreatePaymentResponseAuthorized();
+
+        assertTrue(sut.isAuthorized());
+    }
+
+    @Test
+    @DisplayName("It should convert to an instance of class CreatePaymentResponseAuthorized")
+    public void shouldConvertToAuthorized() {
+        CreatePaymentResponse sut = new CreatePaymentResponseAuthorized();
+
+        assertDoesNotThrow(sut::asAuthorized);
+    }
+
+    @Test
+    @DisplayName("It should throw an error when converting to CreatePaymentResponseAuthorized")
+    public void shouldNotConvertToAuthorized() {
+        CreatePaymentResponse sut = new CreatePaymentResponseFailed(null, null);
+
+        Throwable thrown = assertThrows(TrueLayerException.class, sut::asAuthorized);
+
+        assertEquals(String.format("Response is of type %s.", sut.getClass().getSimpleName()), thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("It should yield true if instance is of type CreatePaymentResponseFailed")
+    public void shouldYieldTrueIfFailed() {
+        CreatePaymentResponse sut = new CreatePaymentResponseFailed("some stage", "some reason");
+
+        assertTrue(sut.isFailed());
+    }
+
+    @Test
+    @DisplayName("It should convert to an instance of class CreatePaymentResponseFailed")
+    public void shouldConvertToFailed() {
+        CreatePaymentResponse sut = new CreatePaymentResponseFailed("some stage", "some reason");
+
+        assertDoesNotThrow(sut::asFailed);
+    }
+
+    @Test
+    @DisplayName("It should throw an error when converting to CreatePaymentResponseFailed")
+    public void shouldNotConvertToFailed() {
+        CreatePaymentResponse sut = new CreatePaymentResponseAuthorized();
+
+        Throwable thrown = assertThrows(TrueLayerException.class, sut::asFailed);
+
+        assertEquals(String.format("Response is of type %s.", sut.getClass().getSimpleName()), thrown.getMessage());
+    }
+}

--- a/src/test/resources/__files/payments/201.create_payment.authorization_required.json
+++ b/src/test/resources/__files/payments/201.create_payment.authorization_required.json
@@ -1,0 +1,8 @@
+{
+  "id":"40d65bb9-642d-48e7-a743-***",
+  "user":{
+    "id":"332d7a9a-aaaa-4ae4-9d2f-***"
+  },
+  "resource_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.***",
+  "status": "authorization_required"
+}

--- a/src/test/resources/__files/payments/201.create_payment.authorized.json
+++ b/src/test/resources/__files/payments/201.create_payment.authorized.json
@@ -3,5 +3,6 @@
   "user":{
     "id":"332d7a9a-aaaa-4ae4-9d2f-***"
   },
-  "resource_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.***"
+  "resource_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.***",
+  "status": "authorized"
 }

--- a/src/test/resources/__files/payments/201.create_payment.failed.json
+++ b/src/test/resources/__files/payments/201.create_payment.failed.json
@@ -1,0 +1,10 @@
+{
+  "id":"40d65bb9-642d-48e7-a743-***",
+  "user":{
+    "id":"332d7a9a-aaaa-4ae4-9d2f-***"
+  },
+  "resource_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.***",
+  "status": "failed",
+  "failure_stage": "authorization_required",
+  "failure_reason": "rejected"
+}


### PR DESCRIPTION
# Description

Adds different statuses to the create payment response.

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation