### PR TITLE
Fix type of `inputs` field of Form response object

### DIFF
--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Form.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Form.java
@@ -10,5 +10,5 @@ import lombok.Value;
 public class Form extends AuthorizationFlowAction {
     Type type = Type.FORM;
 
-    List<Input.Type> inputs;
+    List<Input> inputs;
 }


### PR DESCRIPTION
# Description

Fix type of inputs field of Form response object.
I belive it should be `List<Input> inputs`, not `List<Input.Type> inputs`.
See sample response
https://github.com/TrueLayer/truelayer-java/blob/main/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.form.json

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation