### PR TITLE
fix: `form` and `consent` action response deserialisation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=2.5.0
+version=2.5.1
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowAction.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowAction.java
@@ -17,6 +17,8 @@ import lombok.ToString;
         defaultImpl = ProviderSelection.class)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = ProviderSelection.class, name = "provider_selection"),
+    @JsonSubTypes.Type(value = Consent.class, name = "consent"),
+    @JsonSubTypes.Type(value = Form.class, name = "form"),
     @JsonSubTypes.Type(value = WaitForOutcome.class, name = "wait"),
     @JsonSubTypes.Type(value = Redirect.class, name = "redirect")
 })

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Form.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Form.java
@@ -10,5 +10,5 @@ import lombok.Value;
 public class Form extends AuthorizationFlowAction {
     Type type = Type.FORM;
 
-    List<Input.Type> inputs;
+    List<Input> inputs;
 }

--- a/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.form.json
+++ b/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.form.json
@@ -50,7 +50,7 @@
               }
             ],
             "image": {
-              "type": "base_64",
+              "type": "base64",
               "data": "image_data",
               "media_type": "media_type"
             }


### PR DESCRIPTION
# Description

Fixes an issue with the `form` and `consent` action responses. Due to a missing annotation, they were not correctly deserialised as such. 

This PR constitudes a quick fix. However, we will need to implement more robust tests for deserialisation to avoid similar issues.

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation