### PR TITLE
[EWT-79] Default READ timeout reviewed + bugfix for existing custom timeout logic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=4.0.2
+version=4.1.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/http/OkHttpClientFactory.java
+++ b/src/main/java/com/truelayer/java/http/OkHttpClientFactory.java
@@ -30,10 +30,10 @@ import okhttp3.OkHttpClient;
 @Value
 public class OkHttpClientFactory {
 
-    // This default read timeout takes into account our public API ingress timeout of 30s and adds
+    // This default read timeout takes into account our public API ingress timeout of 29s and adds
     // some extra delay to let very unlucky requests to still go through and/or proper server timeout errors to be
     // properly propagated in the worst case.
-    public static final Duration DEFAULT_TL_CLIENT_READ_TIMEOUT = Duration.ofSeconds(32);
+    public static final Duration DEFAULT_TL_CLIENT_READ_TIMEOUT = Duration.ofSeconds(30);
 
     LibraryInfoLoader libraryInfoLoader;
 

--- a/src/test/java/com/truelayer/java/integration/TimeoutIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/TimeoutIntegrationTests.java
@@ -19,8 +19,9 @@ import org.junit.jupiter.api.*;
 public class TimeoutIntegrationTests extends IntegrationTests {
 
     private static final int A_TIMEOUT_MS = 300;
+    private static final int API_RESPONSE_TIME_MS = 1000;
 
-    // overrides the default implementation by setting a timeout
+    // overrides the default setup by setting a custom call timeout
     @BeforeEach
     @Override
     public void setup(WireMockRuntimeInfo wireMockRuntimeInfo) {
@@ -43,7 +44,7 @@ public class TimeoutIntegrationTests extends IntegrationTests {
                 .path(urlPathEqualTo("/connect/token"))
                 .status(200)
                 .bodyFile("auth/200.access_token.json")
-                .delayMs(1000)
+                .delayMs(API_RESPONSE_TIME_MS)
                 .build();
 
         assertThrows(


### PR DESCRIPTION
# Description
- New feature: a default value is set for read timeouts on our base HTTP client. The values is inline with our API ingress timeout. 
- Bugfix: This PR solves a bug in the existing custom timeout logic: before this, while setting a custom (call) timeout we did not reset the default values for _connect_, _write_ and _read_ timeout, coming with the OkHttp library. Before this release, a customer setting a custom value > 10s, could still hit one of the underlying connect/write/read timeouts at 10s.

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation