### PR TITLE
[EWT-135] feat: adds support for `X-Forwarded-For` HTTP header in start auth flow for single payments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     // to unleash the lombok magic
-    id "io.freefair.lombok" version "6.6.3"
+    id "io.freefair.lombok" version "8.0.1"
     // to make our tests output more fancy
     id 'com.adarshr.test-logger' version '3.2.0'
     // to publish packages
@@ -10,7 +10,7 @@ plugins {
     id "com.diffplug.spotless" version "6.17.0"
     //  test coverage
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
+    id 'com.github.kt3k.coveralls' version '2.12.2'
     // signing
     id "signing"
     // nexus publishing

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=6.0.1
+version=6.1.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/Constants.java
+++ b/src/main/java/com/truelayer/java/Constants.java
@@ -28,6 +28,7 @@ public final class Constants {
         public static final String TL_SIGNATURE = "Tl-Signature";
         public static final String TL_AGENT = "TL-Agent";
         public static final String AUTHORIZATION = "Authorization";
+        public static final String X_FORWARDED_FOR = "X-Forwarded-For";
         public static final String COOKIE = "Cookie";
         public static final String TL_CORRELATION_ID = "X-Tl-Correlation-Id";
     }

--- a/src/main/java/com/truelayer/java/payments/IPaymentsApi.java
+++ b/src/main/java/com/truelayer/java/payments/IPaymentsApi.java
@@ -1,13 +1,12 @@
 package com.truelayer.java.payments;
 
+import static com.truelayer.java.Constants.HeaderNames.X_FORWARDED_FOR;
+
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.payments.entities.*;
 import com.truelayer.java.payments.entities.paymentdetail.PaymentDetail;
 import java.util.concurrent.CompletableFuture;
-import retrofit2.http.Body;
-import retrofit2.http.GET;
-import retrofit2.http.POST;
-import retrofit2.http.Path;
+import retrofit2.http.*;
 
 /**
  * Exposes all the payments related capabilities of the library.
@@ -44,6 +43,21 @@ public interface IPaymentsApi {
     @POST("/payments/{id}/authorization-flow")
     CompletableFuture<ApiResponse<AuthorizationFlowResponse>> startAuthorizationFlow(
             @Path("id") String paymentId, @Body StartAuthorizationFlowRequest request);
+
+    /**
+     * Starts an authorization flow for a given payment resource,
+     * including the <code>X-Forwarded-For</code> HTTP header field to record the end-user IP address.
+     * @param paymentId the payment identifier
+     * @param request a start authorization flow request payload
+     * @param xForwardedFor the end-user IP address
+     * @return the response of the <i>Start Authorization Flow</i> operation
+     * @see <a href="https://docs.truelayer.com/reference/start-payment-authorization-flow"><i>Start Authorization Flow</i> API reference</a>
+     */
+    @POST("/payments/{id}/authorization-flow")
+    CompletableFuture<ApiResponse<AuthorizationFlowResponse>> startAuthorizationFlow(
+            @Path("id") String paymentId,
+            @Body StartAuthorizationFlowRequest request,
+            @Header(X_FORWARDED_FOR) String xForwardedFor);
 
     /**
      * Submit the provider selection for a given payment resource.

--- a/src/test/java/com/truelayer/java/TestUtils.java
+++ b/src/test/java/com/truelayer/java/TestUtils.java
@@ -105,6 +105,7 @@ public class TestUtils {
         private int status;
         private String bodyFile;
         private Integer delayMilliseconds;
+        private String xForwardedForHeader;
 
         private RequestStub() {}
 
@@ -147,6 +148,11 @@ public class TestUtils {
             return this;
         }
 
+        public RequestStub withXForwardedForHeader(String ipAddress) {
+            this.xForwardedForHeader = ipAddress;
+            return this;
+        }
+
         public RequestStub delayMs(int delayMilliseconds) {
             this.delayMilliseconds = delayMilliseconds;
             return this;
@@ -165,6 +171,10 @@ public class TestUtils {
 
             if (withIdempotencyKey) {
                 request.withHeader(IDEMPOTENCY_KEY, matching(UUID_REGEX_PATTERN));
+            }
+
+            if (!isEmpty(xForwardedForHeader)) {
+                request.withHeader(X_FORWARDED_FOR, equalTo(xForwardedForHeader));
             }
 
             ResponseDefinitionBuilder response = aResponse()


### PR DESCRIPTION
# Description

Adds the possibility to specify the X-Forwarded-For header field on [Start authorisation flow API request](https://docs.truelayer.com/reference/start-payment-authorization-flow). 

Implements #194

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation