### PR TITLE
Add payment settlement_risk field to relevant PaymentDetail classes

### DIFF
--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/ExecutedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/ExecutedPaymentDetail.java
@@ -19,8 +19,15 @@ public class ExecutedPaymentDetail extends PaymentDetail {
 
     AuthorizationFlowWithConfiguration authorizationFlow;
 
+    SettlementRisk settlementRisk;
+
     @JsonGetter
     public Optional<AuthorizationFlowWithConfiguration> getAuthorizationFlow() {
         return Optional.ofNullable(authorizationFlow);
+    }
+
+    @JsonGetter
+    public Optional<SettlementRisk> getSettlementRisk() {
+        return Optional.ofNullable(settlementRisk);
     }
 }

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettledPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettledPaymentDetail.java
@@ -1,14 +1,11 @@
 package com.truelayer.java.payments.entities.paymentdetail;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
 import com.truelayer.java.entities.PaymentSource;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 @Value
@@ -27,24 +24,15 @@ public class SettledPaymentDetail extends PaymentDetail {
 
     AuthorizationFlowWithConfiguration authorizationFlow;
 
+    SettlementRisk settlementRisk;
+
     @JsonGetter
     public Optional<AuthorizationFlowWithConfiguration> getAuthorizationFlow() {
         return Optional.ofNullable(authorizationFlow);
     }
 
-    @Value
-    @EqualsAndHashCode
-    public static class SettlementRisk {
-        Category category;
-
-        @RequiredArgsConstructor
-        @Getter
-        public enum Category {
-            LOW_RISK("low_risk"),
-            HIGH_RISK("high_risk");
-
-            @JsonValue
-            private final String category;
-        }
+    @JsonGetter
+    public Optional<SettlementRisk> getSettlementRisk() {
+        return Optional.ofNullable(settlementRisk);
     }
 }

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettlementRisk.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettlementRisk.java
@@ -1,0 +1,21 @@
+package com.truelayer.java.payments.entities.paymentdetail;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+@Value
+public class SettlementRisk {
+    Category category;
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum Category {
+        LOW_RISK("low_risk"),
+        HIGH_RISK("high_risk");
+
+        @JsonValue
+        private final String category;
+    }
+}

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
@@ -132,6 +132,7 @@ class PaymentDetailTests {
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
+                null,
                 null);
 
         assertTrue(sut.isSettled());
@@ -145,6 +146,7 @@ class PaymentDetailTests {
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
+                null,
                 null);
 
         assertDoesNotThrow(sut::asSettled);
@@ -163,7 +165,7 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should yield true if instance is of type ExecutedPaymentDetail")
     public void shouldYieldTrueIfExecutedPaymentDetail() {
-        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null);
+        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null, null);
 
         assertTrue(sut.isExecuted());
     }
@@ -171,7 +173,7 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should convert to an instance of class ExecutedPaymentDetail")
     public void shouldConvertToExecutedPaymentDetail() {
-        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null);
+        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null, null);
 
         assertDoesNotThrow(sut::asExecuted);
     }


### PR DESCRIPTION
# Description

Adds support for accessing the `settlement_risk` field on the ExecutedPaymentDetail and SettledPaymentDetail classes as described in the API documentation: https://docs.truelayer.com/reference/get-payment-1.

[Fixes #226]

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation