### PR TITLE
[DNTT-165] Adds support for related_products object, X-Device-User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TrueLayer Java
 
-[![Build](https://github.com/TrueLayer/truelayer-java/actions/workflows/build.yml/badge.svg)](https://github.com/TrueLayer/truelayer-java/actions/workflows/build.yml)
+[![Release final version](https://github.com/TrueLayer/truelayer-java/actions/workflows/release-final.yml/badge.svg)](https://github.com/TrueLayer/truelayer-java/actions/workflows/release-final.yml)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.truelayer/truelayer-java/badge.svg?style=flat)](https://search.maven.org/artifact/com.truelayer/truelayer-java)
 [![javadoc](https://javadoc.io/badge2/com.truelayer/truelayer-java/javadoc.svg)](https://javadoc.io/doc/com.truelayer/truelayer-java)
 [![Coverage Status](https://coveralls.io/repos/github/TrueLayer/truelayer-java/badge.svg?t=gcGKQv)](https://coveralls.io/github/TrueLayer/truelayer-java)

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java-library'
     // to unleash the lombok magic
-    id "io.freefair.lombok" version "8.3"
+    id "io.freefair.lombok" version "8.4"
     // to make our tests output more fancy
     id 'com.adarshr.test-logger' version '3.2.0'
     // to publish packages
     id 'maven-publish'
     // code linting
-    id "com.diffplug.spotless" version "6.21.0"
+    id "com.diffplug.spotless" version "6.22.0"
     //  test coverage
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=10.0.0
+version=10.1.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/Constants.java
+++ b/src/main/java/com/truelayer/java/Constants.java
@@ -32,6 +32,7 @@ public final class Constants {
         public static final String AUTHORIZATION = "Authorization";
         public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
         public static final String X_FORWARDED_FOR = "X-Forwarded-For";
+        public static final String X_DEVICE_USER_AGENT = "X-Device-User-Agent";
         public static final String COOKIE = "Cookie";
         public static final String TL_CORRELATION_ID = "X-Tl-Correlation-Id";
     }

--- a/src/main/java/com/truelayer/java/entities/RelatedProducts.java
+++ b/src/main/java/com/truelayer/java/entities/RelatedProducts.java
@@ -1,0 +1,16 @@
+package com.truelayer.java.entities;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class RelatedProducts {
+
+    private Map<String, String> signupPlus;
+}

--- a/src/main/java/com/truelayer/java/http/entities/Headers.java
+++ b/src/main/java/com/truelayer/java/http/entities/Headers.java
@@ -18,4 +18,6 @@ public class Headers {
     private String signature;
 
     private String xForwardedFor;
+
+    private String xDeviceUserAgent;
 }

--- a/src/main/java/com/truelayer/java/http/mappers/HeadersMapper.java
+++ b/src/main/java/com/truelayer/java/http/mappers/HeadersMapper.java
@@ -35,6 +35,11 @@ public class HeadersMapper {
             headersMap.put(Constants.HeaderNames.X_FORWARDED_FOR, xForwardedFor);
         }
 
+        String xDeviceUserAgent = customHeaders.getXDeviceUserAgent();
+        if (isNotEmpty(xDeviceUserAgent)) {
+            headersMap.put(Constants.HeaderNames.X_DEVICE_USER_AGENT, xDeviceUserAgent);
+        }
+
         return Collections.unmodifiableMap(headersMap);
     }
 }

--- a/src/main/java/com/truelayer/java/mandates/entities/CreateMandateRequest.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/CreateMandateRequest.java
@@ -1,6 +1,7 @@
 package com.truelayer.java.mandates.entities;
 
 import com.truelayer.java.entities.CurrencyCode;
+import com.truelayer.java.entities.RelatedProducts;
 import com.truelayer.java.entities.User;
 import com.truelayer.java.mandates.entities.mandate.Mandate;
 import java.util.Map;
@@ -24,4 +25,6 @@ public class CreateMandateRequest {
     private Constraints constraints;
 
     private Map<String, String> metadata;
+
+    private RelatedProducts relatedProducts;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/CreatePaymentRequest.java
+++ b/src/main/java/com/truelayer/java/payments/entities/CreatePaymentRequest.java
@@ -1,6 +1,7 @@
 package com.truelayer.java.payments.entities;
 
 import com.truelayer.java.entities.CurrencyCode;
+import com.truelayer.java.entities.RelatedProducts;
 import com.truelayer.java.entities.User;
 import com.truelayer.java.payments.entities.paymentmethod.PaymentMethod;
 import java.util.Map;
@@ -23,4 +24,9 @@ public class CreatePaymentRequest {
     private User user;
 
     private Map<String, String> metadata;
+
+    /**
+     * Optional field. Not available when creating recurring payments.
+     */
+    private RelatedProducts relatedProducts;
 }

--- a/src/test/java/com/truelayer/java/TestUtils.java
+++ b/src/test/java/com/truelayer/java/TestUtils.java
@@ -107,6 +107,7 @@ public class TestUtils {
         private String bodyFile;
         private Integer delayMilliseconds;
         private String xForwardedForHeader;
+        private String xDeviceUserAgent;
 
         private RequestStub() {}
 
@@ -154,6 +155,11 @@ public class TestUtils {
             return this;
         }
 
+        public RequestStub withXDeviceUserAgent(String deviceUserAgent) {
+            this.xDeviceUserAgent = deviceUserAgent;
+            return this;
+        }
+
         public RequestStub delayMs(int delayMilliseconds) {
             this.delayMilliseconds = delayMilliseconds;
             return this;
@@ -176,6 +182,10 @@ public class TestUtils {
 
             if (isNotEmpty(xForwardedForHeader)) {
                 request.withHeader(X_FORWARDED_FOR, equalTo(xForwardedForHeader));
+            }
+
+            if (isNotEmpty(xDeviceUserAgent)) {
+                request.withHeader(X_DEVICE_USER_AGENT, equalTo(xDeviceUserAgent));
             }
 
             ResponseDefinitionBuilder response = aResponse()
@@ -204,6 +214,7 @@ public class TestUtils {
                 .idempotencyKey("a-custom-key_" + randomString)
                 .signature("a-custom-signature_" + randomString)
                 .xForwardedFor("1.2.3.4_" + randomString)
+                .xDeviceUserAgent("ADummyUserAgen")
                 .build();
     }
 }

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -89,6 +89,22 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
     }
 
     @Test
+    @DisplayName("It should create a payment to be used with Signup+")
+    @SneakyThrows
+    public void itShouldCreateAPaymentWithSignupPlusIntention() {
+        ApiResponse<CreatePaymentResponse> createPaymentResponse = tlClient.payments()
+                .createPayment(buildPaymentRequestWithProviderSelection(
+                        buildPreselectedProviderSelection(),
+                        CurrencyCode.GBP,
+                        RelatedProducts.builder()
+                                .signupPlus(Collections.emptyMap())
+                                .build()))
+                .get();
+
+        assertNotError(createPaymentResponse);
+    }
+
+    @Test
     @DisplayName("It should create and get by id a payment with preselected provider")
     @SneakyThrows
     public void shouldCreateAPaymentWithPreselectedProvider() {
@@ -509,10 +525,14 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
         }
     }
 
-    @SneakyThrows
     private CreatePaymentRequest buildPaymentRequestWithProviderSelection(
             ProviderSelection providerSelection, CurrencyCode currencyCode) {
-        return CreatePaymentRequest.builder()
+        return buildPaymentRequestWithProviderSelection(providerSelection, currencyCode, null);
+    }
+
+    private CreatePaymentRequest buildPaymentRequestWithProviderSelection(
+            ProviderSelection providerSelection, CurrencyCode currencyCode, RelatedProducts relatedProducts) {
+        CreatePaymentRequest.CreatePaymentRequestBuilder builder = CreatePaymentRequest.builder()
                 .amountInMinor(RandomUtils.nextInt(50, 500))
                 .currency(currencyCode)
                 .paymentMethod(PaymentMethod.bankTransfer()
@@ -531,8 +551,13 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                                 .countryCode("GB")
                                 .build())
                         .build())
-                .metadata(Collections.singletonMap("a_custom_key", "a-custom-value"))
-                .build();
+                .metadata(Collections.singletonMap("a_custom_key", "a-custom-value"));
+
+        if (relatedProducts != null) {
+            builder.relatedProducts(relatedProducts);
+        }
+
+        return builder.build();
     }
 
     private CreatePaymentRequest buildPaymentRequest(CurrencyCode currencyCode) {

--- a/src/test/java/com/truelayer/java/http/mappers/HeadersMapperTests.java
+++ b/src/test/java/com/truelayer/java/http/mappers/HeadersMapperTests.java
@@ -23,6 +23,7 @@ class HeadersMapperTests {
 
         assertThrows(UnsupportedOperationException.class, () -> headersMap.put("foo", "bar"));
         assertEquals(headers.getXForwardedFor(), headersMap.get(X_FORWARDED_FOR));
+        assertEquals(headers.getXDeviceUserAgent(), headersMap.get(X_DEVICE_USER_AGENT));
         assertEquals(headers.getSignature(), headersMap.get(TL_SIGNATURE));
         assertEquals(headers.getIdempotencyKey(), headersMap.get(IDEMPOTENCY_KEY));
     }


### PR DESCRIPTION
# Description

- feat(DNTT-461): Adds support for related_products when creating payments and mandates
- updated version
- feat(EWT-350): Adds support for X-Device-User-Agent HTTP header on Start authorization flow
- chores: dependencies and readme updates

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation