### PR TITLE
[DNTT-489] Added settlement_risk to executed and settled payment details response types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ dependencies {
 
     // Transitive dependencies constraints
     constraints {
-        implementation('com.squareup.okhttp3:okhttp:4.11.0') {
+        implementation('com.squareup.okhttp3:okhttp:4.12.0') {
             because 'version 3.14.9 used by com.squareup.retrofit2:retrofit:2.9.0 has known vulnerabilities'
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=10.1.1
+version=10.2.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/ExecutedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/ExecutedPaymentDetail.java
@@ -19,8 +19,15 @@ public class ExecutedPaymentDetail extends PaymentDetail {
 
     AuthorizationFlowWithConfiguration authorizationFlow;
 
+    SettlementRisk settlementRisk;
+
     @JsonGetter
     public Optional<AuthorizationFlowWithConfiguration> getAuthorizationFlow() {
         return Optional.ofNullable(authorizationFlow);
+    }
+
+    @JsonGetter
+    public Optional<SettlementRisk> getSettlementRisk() {
+        return Optional.ofNullable(settlementRisk);
     }
 }

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettledPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettledPaymentDetail.java
@@ -27,9 +27,16 @@ public class SettledPaymentDetail extends PaymentDetail {
 
     AuthorizationFlowWithConfiguration authorizationFlow;
 
+    SettlementRisk settlementRisk;
+
     @JsonGetter
     public Optional<AuthorizationFlowWithConfiguration> getAuthorizationFlow() {
         return Optional.ofNullable(authorizationFlow);
+    }
+
+    @JsonGetter
+    public Optional<SettlementRisk> getSettlementRisk() {
+        return Optional.ofNullable(settlementRisk);
     }
 
     @Value

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettlementRisk.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/SettlementRisk.java
@@ -1,0 +1,21 @@
+package com.truelayer.java.payments.entities.paymentdetail;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+@Value
+public class SettlementRisk {
+    Category category;
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum Category {
+        LOW_RISK("low_risk"),
+        HIGH_RISK("high_risk");
+
+        @JsonValue
+        private final String category;
+    }
+}

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
@@ -132,6 +132,7 @@ class PaymentDetailTests {
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
+                null,
                 null);
 
         assertTrue(sut.isSettled());
@@ -145,6 +146,7 @@ class PaymentDetailTests {
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
                 ZonedDateTime.now(Clock.systemUTC()),
+                null,
                 null);
 
         assertDoesNotThrow(sut::asSettled);
@@ -163,7 +165,7 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should yield true if instance is of type ExecutedPaymentDetail")
     public void shouldYieldTrueIfExecutedPaymentDetail() {
-        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null);
+        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null, null);
 
         assertTrue(sut.isExecuted());
     }
@@ -171,7 +173,7 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should convert to an instance of class ExecutedPaymentDetail")
     public void shouldConvertToExecutedPaymentDetail() {
-        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null);
+        PaymentDetail sut = new ExecutedPaymentDetail(null, ZonedDateTime.now(Clock.systemUTC()), null, null);
 
         assertDoesNotThrow(sut::asExecuted);
     }


### PR DESCRIPTION
# Description

- Adds the settlement_risk field on executed and settlements payment details types.
- Bumps OkHttp to latest version 

[Fixes #226]

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation