### PR TITLE
[EWT-371] Add payment_source property to authorized and failed payment details

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=10.2.0
+version=10.3.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizedPaymentDetail.java
@@ -3,6 +3,8 @@ package com.truelayer.java.payments.entities.paymentdetail;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
 import java.util.Optional;
+
+import com.truelayer.java.entities.PaymentSource;
 import lombok.*;
 
 @Value
@@ -10,6 +12,8 @@ import lombok.*;
 public class AuthorizedPaymentDetail extends PaymentDetail {
 
     Status status = Status.AUTHORIZED;
+
+    PaymentSource paymentSource;
 
     AuthorizationFlowWithConfiguration authorizationFlow;
 

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizedPaymentDetail.java
@@ -2,9 +2,8 @@ package com.truelayer.java.payments.entities.paymentdetail;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
-import java.util.Optional;
-
 import com.truelayer.java.entities.PaymentSource;
+import java.util.Optional;
 import lombok.*;
 
 @Value

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/FailedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/FailedPaymentDetail.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+
+import com.truelayer.java.entities.PaymentSource;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,8 @@ import lombok.Value;
 public class FailedPaymentDetail extends PaymentDetail {
 
     Status status = Status.FAILED;
+
+    PaymentSource paymentSource;
 
     ZonedDateTime failedAt;
 

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/FailedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/FailedPaymentDetail.java
@@ -3,10 +3,9 @@ package com.truelayer.java.payments.entities.paymentdetail;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
+import com.truelayer.java.entities.PaymentSource;
 import java.time.ZonedDateTime;
 import java.util.Optional;
-
-import com.truelayer.java.entities.PaymentSource;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
@@ -67,7 +67,7 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should yield true if instance is of type AuthorizedPaymentDetail")
     public void shouldYieldTrueIfAuthorizedPaymentDetail() {
-        PaymentDetail sut = new AuthorizedPaymentDetail(new AuthorizationFlowWithConfiguration(null));
+        PaymentDetail sut = new AuthorizedPaymentDetail(null, new AuthorizationFlowWithConfiguration(null));
 
         assertTrue(sut.isAuthorized());
     }
@@ -75,7 +75,7 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should convert to an instance of class AuthorizedPaymentDetail")
     public void shouldConvertToAuthorizedPaymentDetail() {
-        PaymentDetail sut = new AuthorizedPaymentDetail(new AuthorizationFlowWithConfiguration(null));
+        PaymentDetail sut = new AuthorizedPaymentDetail(null, new AuthorizationFlowWithConfiguration(null));
 
         assertDoesNotThrow(sut::asAuthorized);
     }
@@ -94,6 +94,7 @@ class PaymentDetailTests {
     @DisplayName("It should yield true if instance is of type FailedPaymentDetail")
     public void shouldYieldTrueIfFailedPaymentDetail() {
         PaymentDetail sut = new FailedPaymentDetail(
+                null,
                 ZonedDateTime.now(Clock.systemUTC()),
                 FailedPaymentDetail.FailureStage.AUTHORIZATION_REQUIRED,
                 "failed for some reason",
@@ -106,6 +107,7 @@ class PaymentDetailTests {
     @DisplayName("It should convert to an instance of class FailedPaymentDetail")
     public void shouldConvertToFailedPaymentDetail() {
         PaymentDetail sut = new FailedPaymentDetail(
+                null,
                 ZonedDateTime.now(Clock.systemUTC()),
                 FailedPaymentDetail.FailureStage.AUTHORIZATION_REQUIRED,
                 "failed for some reason",

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorized.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorized.json
@@ -55,5 +55,14 @@
   },
   "metadata": {
     "a_custom_key": "a-value"
+  },
+  "payment_source":{
+    "account_identifiers":[
+      {
+        "type":"nrb",
+        "nrb":"123456"
+      }
+    ],
+    "account_holder_name":"John Doe"
   }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.failed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.failed.json
@@ -41,5 +41,14 @@
   "failure_reason":"failed",
   "metadata": {
     "a_custom_key": "a-value"
+  },
+  "payment_source":{
+    "account_identifiers":[
+      {
+        "type":"nrb",
+        "nrb":"123456"
+      }
+    ],
+    "account_holder_name":"John Doe"
   }
 }


### PR DESCRIPTION
# Description

Add `payment_source` property to `Authorized` and `Failed` payment details as per [Get Payment reference docs](https://docs.truelayer.com/reference/get-payment-1)

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation