### PR TITLE
feat(EWT-535): Support for merchant account transactions pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,15 @@ URI hppLink = client.hpp().getHostedPaymentPageLink("your-createPaymentResponse-
 Any version of the JDK >= 8 supported by Gradle can build and run this package.
 Check the [Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html) for more info.
 
-To ensure compatibility, Gradle is configured to use the Java 8 toolchain by default.  
-Note that on M1 Macs, Gradle is unable to download this toolchain automatically and returns the following error:
-`Could not read 'https: //api.adoptopenidk.net/v3/binary/latest/8/ga/mac/aarch64/idk/hotspot/normal/adoptopenidk' as it does not exist.`.
-Manually install an aarch64 version of the JDK 1.8 to solve it, like the "Azul Zulu 1.8" for example.
+> [!IMPORTANT]  
+> To ensure compatibility, Gradle is configured to use the Java 8 toolchain by default.  
+> Note that on M1 Macs, Gradle is unable to download this toolchain automatically and returns the following error:
+> `Could not read 'https: //api.adoptopenidk.net/v3/binary/latest/8/ga/mac/aarch64/idk/hotspot/normal/adoptopenidk' as it does not exist.`.
+> 
+> Manually install an aarch64 version of the JDK 1.8 to solve it, like the "Azul Zulu 1.8" for example.
+
+> [!TIP]
+> We use [just](https://github.com/casey/just) to simplify commands management when building locally. Run `just -l` for a list of recipes.
 
 ## Building locally
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java-library'
     // to unleash the lombok magic
-    id "io.freefair.lombok" version "8.4"
+    id "io.freefair.lombok" version "8.6"
     // to make our tests output more fancy
     id 'com.adarshr.test-logger' version '4.0.0'
     // to publish packages
     id 'maven-publish'
     // code linting
-    id "com.diffplug.spotless" version "6.23.3"
+    id "com.diffplug.spotless" version "6.25.0"
     //  test coverage
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.2'
@@ -110,11 +110,11 @@ dependencies {
     implementation group: 'org.tinylog', name: 'tinylog-impl', version: tinyLogVersion
 
     // JUnit test framework.
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.10.1'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.10.2'
 
     // Mocking libraries
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.8.0'
-    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.3.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.11.0'
+    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.5.2'
 
     // Wait test utility
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=11.0.1
+version=11.1.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+alias b := build
+alias l := lint
+alias ut := unit-test
+alias it := integration-test
+alias at := acceptance-test
+
+build:
+    ./gradlew build -x test
+
+lint:
+    ./gradlew spotlessApply
+
+unit-test:
+    ./gradlew unit-tests
+
+integration-test:
+    ./gradlew integration-tests
+
+acceptance-test:
+    echo "Staring acceptance-tests with client_id=[$TL_CLIENT_ID]..."
+    ./gradlew acceptance-tests

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ alias l := lint
 alias ut := unit-test
 alias it := integration-test
 alias at := acceptance-test
+alias t := test
 
 build:
     ./gradlew build -x test
@@ -19,3 +20,5 @@ integration-test:
 acceptance-test:
     echo "Staring acceptance-tests with client_id=[$TL_CLIENT_ID]..."
     ./gradlew acceptance-tests
+
+test: unit-test integration-test acceptance-test

--- a/src/main/java/com/truelayer/java/Constants.java
+++ b/src/main/java/com/truelayer/java/Constants.java
@@ -37,5 +37,6 @@ public final class Constants {
         public static final String X_DEVICE_USER_AGENT = "X-Device-User-Agent";
         public static final String COOKIE = "Cookie";
         public static final String TL_CORRELATION_ID = "X-Tl-Correlation-Id";
+        public static final String TL_ENABLE_PAGINATION = "tl-enable-pagination";
     }
 }

--- a/src/main/java/com/truelayer/java/http/entities/Headers.java
+++ b/src/main/java/com/truelayer/java/http/entities/Headers.java
@@ -20,4 +20,16 @@ public class Headers {
     private String xForwardedFor;
 
     private String xDeviceUserAgent;
+
+    private boolean enablePagination;
+
+    /**
+     * Custom builder for the Headers class that prevents setting the enablePagination field to false.
+     */
+    public static class HeadersBuilder {
+        public HeadersBuilder enablePagination() {
+            this.enablePagination = true;
+            return this;
+        }
+    }
 }

--- a/src/main/java/com/truelayer/java/http/mappers/HeadersMapper.java
+++ b/src/main/java/com/truelayer/java/http/mappers/HeadersMapper.java
@@ -40,6 +40,10 @@ public class HeadersMapper {
             headersMap.put(Constants.HeaderNames.X_DEVICE_USER_AGENT, xDeviceUserAgent);
         }
 
+        if (customHeaders.isEnablePagination()) {
+            headersMap.put(Constants.HeaderNames.TL_ENABLE_PAGINATION, "true");
+        }
+
         return Collections.unmodifiableMap(headersMap);
     }
 }

--- a/src/main/java/com/truelayer/java/merchantaccounts/IMerchantAccountsApi.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/IMerchantAccountsApi.java
@@ -42,6 +42,7 @@ public interface IMerchantAccountsApi {
     /**
      * Get the transactions of a single merchant account.
      * @param scopes the scopes to be used by the underlying Oauth token
+     * @param headers map representing custom HTTP headers to be sent. In this case used for old clients to opt-in to paginated results
      * @param merchantAccountId the id of the merchant account
      * @param from Timestamp as a string for the start of the range you are querying. Mandatory
      * @param to Timestamp as a string for the end of the range you are querying. Mandatory
@@ -52,6 +53,7 @@ public interface IMerchantAccountsApi {
     @GET("/merchant-accounts/{merchantAccountId}/transactions")
     CompletableFuture<ApiResponse<ListTransactionsResponse>> listTransactions(
             @Tag RequestScopes scopes,
+            @HeaderMap Map<String, String> headers,
             @Path("merchantAccountId") String merchantAccountId,
             @Query("from") String from,
             @Query("to") String to,

--- a/src/main/java/com/truelayer/java/merchantaccounts/IMerchantAccountsApi.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/IMerchantAccountsApi.java
@@ -55,7 +55,8 @@ public interface IMerchantAccountsApi {
             @Path("merchantAccountId") String merchantAccountId,
             @Query("from") String from,
             @Query("to") String to,
-            @Query("type") TransactionTypeQuery type);
+            @Query("type") TransactionTypeQuery type,
+            @Query("cursor") String cursor);
 
     /**
      * Set the automatic sweeping settings for a merchant account. At regular intervals, any available balance in excess

--- a/src/main/java/com/truelayer/java/merchantaccounts/IMerchantAccountsHandler.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/IMerchantAccountsHandler.java
@@ -16,6 +16,21 @@ public interface IMerchantAccountsHandler {
     CompletableFuture<ApiResponse<ListTransactionsResponse>> listTransactions(
             String merchantAccountId, ListTransactionsQuery query);
 
+    /**
+     * Overload meant to give clients created before December 2023 the ability to opt-in for paginated results at a <i>request</i> level via the
+     * <code>tl-enable-pagination</code> HTTP header.<br>
+     * This is useful for clients that want to ease the migration towards paginated responses, it is not required once
+     * the pagination opt-in is enabled at the client level.<br>
+     * See <a href="https://docs.truelayer.com/docs/enable-pagination-transactions-endpoint#enable-pagination">Enable pagination</a> for more details.<br><br>
+     * Clients created after November 2023 can use the {@link #listTransactions(String, ListTransactionsQuery) simpler overload}.
+     * @param headers map representing custom HTTP headers to be sent. In this case used to specify the {@link Headers#enablePagination enablePagination} flag
+     * @param merchantAccountId the id of the merchant account
+     * @param query the query to filter the transactions
+     * @return a list of transactions matching the specified filters
+     */
+    CompletableFuture<ApiResponse<ListTransactionsResponse>> listTransactions(
+            Headers headers, String merchantAccountId, ListTransactionsQuery query);
+
     CompletableFuture<ApiResponse<SweepingSettings>> updateSweeping(
             String merchantAccountId, UpdateSweepingRequest updateSweepingRequest);
 

--- a/src/main/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandler.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandler.java
@@ -41,7 +41,8 @@ public class MerchantAccountsHandler implements IAuthenticatedHandler, IMerchant
             String merchantAccountId, ListTransactionsQuery query) {
         String from = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(query.from());
         String to = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(query.to());
-        return merchantAccountsApi.listTransactions(getRequestScopes(), merchantAccountId, from, to, query.type());
+        return merchantAccountsApi.listTransactions(getRequestScopes(),
+                merchantAccountId, from, to, query.type(), query.cursor());
     }
 
     @Override

--- a/src/main/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandler.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandler.java
@@ -41,8 +41,17 @@ public class MerchantAccountsHandler implements IAuthenticatedHandler, IMerchant
             String merchantAccountId, ListTransactionsQuery query) {
         String from = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(query.from());
         String to = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(query.to());
-        return merchantAccountsApi.listTransactions(getRequestScopes(),
-                merchantAccountId, from, to, query.type(), query.cursor());
+        return merchantAccountsApi.listTransactions(
+                getRequestScopes(), emptyMap(), merchantAccountId, from, to, query.type(), query.cursor());
+    }
+
+    @Override
+    public CompletableFuture<ApiResponse<ListTransactionsResponse>> listTransactions(
+            Headers headers, String merchantAccountId, ListTransactionsQuery query) {
+        String from = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(query.from());
+        String to = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(query.to());
+        return merchantAccountsApi.listTransactions(
+                getRequestScopes(), toMap(headers), merchantAccountId, from, to, query.type(), query.cursor());
     }
 
     @Override

--- a/src/main/java/com/truelayer/java/merchantaccounts/entities/ListTransactionsQuery.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/entities/ListTransactionsQuery.java
@@ -15,4 +15,6 @@ public class ListTransactionsQuery {
     private ZonedDateTime to;
 
     private TransactionTypeQuery type;
+
+    private String cursor;
 }

--- a/src/main/java/com/truelayer/java/merchantaccounts/entities/ListTransactionsResponse.java
+++ b/src/main/java/com/truelayer/java/merchantaccounts/entities/ListTransactionsResponse.java
@@ -1,5 +1,6 @@
 package com.truelayer.java.merchantaccounts.entities;
 
+import com.truelayer.java.entities.PaginationMetadata;
 import com.truelayer.java.merchantaccounts.entities.transactions.Transaction;
 import java.util.List;
 import lombok.Value;
@@ -8,4 +9,6 @@ import lombok.Value;
 public class ListTransactionsResponse {
 
     List<Transaction> items;
+
+    PaginationMetadata pagination;
 }

--- a/src/test/java/com/truelayer/java/TestUtils.java
+++ b/src/test/java/com/truelayer/java/TestUtils.java
@@ -219,7 +219,8 @@ public class TestUtils {
                 .idempotencyKey("a-custom-key_" + randomString)
                 .signature("a-custom-signature_" + randomString)
                 .xForwardedFor("1.2.3.4_" + randomString)
-                .xDeviceUserAgent("ADummyUserAgen")
+                .xDeviceUserAgent("ADummyUserAgent")
+                .enablePagination()
                 .build();
     }
 

--- a/src/test/java/com/truelayer/java/acceptance/MerchantAccountsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MerchantAccountsAcceptanceTests.java
@@ -4,6 +4,7 @@ import static com.truelayer.java.TestUtils.assertNotError;
 
 import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.http.entities.ApiResponse;
+import com.truelayer.java.http.entities.Headers;
 import com.truelayer.java.merchantaccounts.entities.*;
 import com.truelayer.java.merchantaccounts.entities.sweeping.Frequency;
 import com.truelayer.java.merchantaccounts.entities.sweeping.SweepingSettings;
@@ -133,6 +134,9 @@ public class MerchantAccountsAcceptanceTests extends AcceptanceTests {
     private ApiResponse<ListTransactionsResponse> getTransactions(ZonedDateTime from, ZonedDateTime to) {
         return tlClient.merchantAccounts()
                 .listTransactions(
+                        Headers.builder()
+                                .enablePagination()
+                                .build(), // Required for clients before December 2023 to opt-in for paginated results
                         getMerchantAccount(CurrencyCode.GBP).getId(),
                         ListTransactionsQuery.builder().from(from).to(to).build())
                 .get();
@@ -141,11 +145,11 @@ public class MerchantAccountsAcceptanceTests extends AcceptanceTests {
     private static Stream<Arguments> provideFromAndToParameters() {
         return Stream.of(
                 Arguments.of(
-                        ZonedDateTime.of(LocalDate.of(2021, 3, 1), LocalTime.MIN, ZoneId.of("UTC")),
-                        ZonedDateTime.of(LocalDate.of(2022, 3, 1), LocalTime.MIN, ZoneId.of("UTC"))),
+                        ZonedDateTime.of(LocalDate.of(2024, 2, 1), LocalTime.MIN, ZoneId.of("UTC")),
+                        ZonedDateTime.of(LocalDate.of(2024, 3, 1), LocalTime.MIN, ZoneId.of("UTC"))),
                 Arguments.of(
-                        ZonedDateTime.of(LocalDate.of(2021, 3, 1), LocalTime.MIN, ZoneId.of("Europe/Paris")),
-                        ZonedDateTime.of(LocalDate.of(2022, 3, 1), LocalTime.MIN, ZoneId.of("Europe/Paris"))),
-                Arguments.of(ZonedDateTime.parse("2021-03-01T00:00:00Z"), ZonedDateTime.parse("2022-03-01T00:00:00Z")));
+                        ZonedDateTime.of(LocalDate.of(2024, 2, 1), LocalTime.MIN, ZoneId.of("Europe/Paris")),
+                        ZonedDateTime.of(LocalDate.of(2024, 3, 1), LocalTime.MIN, ZoneId.of("Europe/Paris"))),
+                Arguments.of(ZonedDateTime.parse("2024-02-01T00:00:00Z"), ZonedDateTime.parse("2024-03-01T00:00:00Z")));
     }
 }

--- a/src/test/java/com/truelayer/java/integration/HttpHeadersManagementTests.java
+++ b/src/test/java/com/truelayer/java/integration/HttpHeadersManagementTests.java
@@ -55,12 +55,14 @@ public class HttpHeadersManagementTests extends IntegrationTests {
                         Headers.builder()
                                 .signature(signature)
                                 .idempotencyKey(idempotencyKey)
+                                .enablePagination()
                                 .build(),
                         paymentRequest)
                 .get();
 
         verifyGeneratedToken(Collections.singletonList(Constants.Scopes.PAYMENTS));
         verify(postRequestedFor(urlPathEqualTo("/payments"))
+                .withHeader(TL_ENABLE_PAGINATION, equalTo("true"))
                 .withHeader(TL_SIGNATURE, equalTo(signature))
                 .withHeader(IDEMPOTENCY_KEY, equalTo(idempotencyKey)));
     }

--- a/src/test/java/com/truelayer/java/integration/MerchantAccountsIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/MerchantAccountsIntegrationTests.java
@@ -176,7 +176,7 @@ public class MerchantAccountsIntegrationTests extends IntegrationTests {
     @SneakyThrows
     @Test
     @DisplayName(
-            "It should get the list of transactions for a given merchant account with pagination cursor with HTTP opt-in header")
+            "It should get the list of transactions for a given merchant account with pagination cursor with HTTP header opt-in")
     public void shouldGetTransactionsWithPaginationCursorWithHttpHeaderOptIn() {
         String jsonResponseFile = "merchant_accounts/200.get_transactions.json";
         RequestStub.New()

--- a/src/test/java/com/truelayer/java/integration/MerchantAccountsIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/MerchantAccountsIntegrationTests.java
@@ -1,6 +1,7 @@
 package com.truelayer.java.integration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.truelayer.java.Constants.HeaderNames.TL_ENABLE_PAGINATION;
 import static com.truelayer.java.Constants.Scopes.PAYMENTS;
 import static com.truelayer.java.TestUtils.assertNotError;
 import static com.truelayer.java.TestUtils.deserializeJsonFileTo;
@@ -9,20 +10,17 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.truelayer.java.TestUtils.RequestStub;
 import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.http.entities.ApiResponse;
+import com.truelayer.java.http.entities.Headers;
 import com.truelayer.java.merchantaccounts.entities.*;
 import com.truelayer.java.merchantaccounts.entities.sweeping.Frequency;
 import com.truelayer.java.merchantaccounts.entities.sweeping.SweepingSettings;
 import com.truelayer.java.merchantaccounts.entities.transactions.TransactionTypeQuery;
 import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.UUID;
-
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Merchant accounts integration tests")
 public class MerchantAccountsIntegrationTests extends IntegrationTests {
@@ -119,6 +117,7 @@ public class MerchantAccountsIntegrationTests extends IntegrationTests {
 
         verifyGeneratedToken(Collections.singletonList(PAYMENTS));
         verify(getRequestedFor(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withoutHeader(TL_ENABLE_PAGINATION)
                 .withQueryParam("from", equalTo(to))
                 .withQueryParam("from", equalTo(from))
                 .withQueryParam("type", equalTo(TransactionTypeQuery.PAYMENT.toString()))
@@ -163,6 +162,53 @@ public class MerchantAccountsIntegrationTests extends IntegrationTests {
 
         verifyGeneratedToken(Collections.singletonList(PAYMENTS));
         verify(getRequestedFor(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withoutHeader(TL_ENABLE_PAGINATION)
+                .withQueryParam("from", equalTo(to))
+                .withQueryParam("from", equalTo(from))
+                .withQueryParam("type", equalTo(TransactionTypeQuery.PAYMENT.toString()))
+                .withQueryParam("cursor", equalTo(cursor)));
+
+        assertNotError(response);
+        ListTransactionsResponse expected = deserializeJsonFileTo(jsonResponseFile, ListTransactionsResponse.class);
+        assertEquals(expected, response.getData());
+    }
+
+    @SneakyThrows
+    @Test
+    @DisplayName(
+            "It should get the list of transactions for a given merchant account with pagination cursor with HTTP opt-in header")
+    public void shouldGetTransactionsWithPaginationCursorWithHttpHeaderOptIn() {
+        String jsonResponseFile = "merchant_accounts/200.get_transactions.json";
+        RequestStub.New()
+                .method("post")
+                .path(urlPathEqualTo("/connect/token"))
+                .status(200)
+                .bodyFile("auth/200.access_token.json")
+                .build();
+        RequestStub.New()
+                .method("get")
+                .path(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withAuthorization()
+                .status(200)
+                .bodyFile(jsonResponseFile)
+                .build();
+
+        String from = "2022-01-01T00:00:00Z";
+        String to = "2022-03-01T00:00:00Z";
+        String cursor = UUID.randomUUID().toString();
+        ListTransactionsQuery query = ListTransactionsQuery.builder()
+                .from(ZonedDateTime.parse(from))
+                .to(ZonedDateTime.parse(to))
+                .type(TransactionTypeQuery.PAYMENT)
+                .cursor(cursor)
+                .build();
+        ApiResponse<ListTransactionsResponse> response = tlClient.merchantAccounts()
+                .listTransactions(Headers.builder().enablePagination().build(), A_MERCHANT_ACCOUNT_ID, query)
+                .get();
+
+        verifyGeneratedToken(Collections.singletonList(PAYMENTS));
+        verify(getRequestedFor(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withHeader(TL_ENABLE_PAGINATION, equalTo("true"))
                 .withQueryParam("from", equalTo(to))
                 .withQueryParam("from", equalTo(from))
                 .withQueryParam("type", equalTo(TransactionTypeQuery.PAYMENT.toString()))

--- a/src/test/java/com/truelayer/java/integration/MerchantAccountsIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/MerchantAccountsIntegrationTests.java
@@ -1,6 +1,6 @@
 package com.truelayer.java.integration;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.truelayer.java.Constants.Scopes.PAYMENTS;
 import static com.truelayer.java.TestUtils.assertNotError;
 import static com.truelayer.java.TestUtils.deserializeJsonFileTo;
@@ -15,9 +15,14 @@ import com.truelayer.java.merchantaccounts.entities.sweeping.SweepingSettings;
 import com.truelayer.java.merchantaccounts.entities.transactions.TransactionTypeQuery;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Merchant accounts integration tests")
 public class MerchantAccountsIntegrationTests extends IntegrationTests {
@@ -101,9 +106,11 @@ public class MerchantAccountsIntegrationTests extends IntegrationTests {
                 .bodyFile(jsonResponseFile)
                 .build();
 
+        String from = "2022-01-01T00:00:00Z";
+        String to = "2022-03-01T00:00:00Z";
         ListTransactionsQuery query = ListTransactionsQuery.builder()
-                .from(ZonedDateTime.parse("2021-03-01T00:00:00Z"))
-                .to(ZonedDateTime.parse("2022-03-01T00:00:00Z"))
+                .from(ZonedDateTime.parse(from))
+                .to(ZonedDateTime.parse(to))
                 .type(TransactionTypeQuery.PAYMENT)
                 .build();
         ApiResponse<ListTransactionsResponse> response = tlClient.merchantAccounts()
@@ -111,6 +118,56 @@ public class MerchantAccountsIntegrationTests extends IntegrationTests {
                 .get();
 
         verifyGeneratedToken(Collections.singletonList(PAYMENTS));
+        verify(getRequestedFor(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withQueryParam("from", equalTo(to))
+                .withQueryParam("from", equalTo(from))
+                .withQueryParam("type", equalTo(TransactionTypeQuery.PAYMENT.toString()))
+                .withoutQueryParam("cursor"));
+
+        assertNotError(response);
+        ListTransactionsResponse expected = deserializeJsonFileTo(jsonResponseFile, ListTransactionsResponse.class);
+        assertEquals(expected, response.getData());
+    }
+
+    @SneakyThrows
+    @Test
+    @DisplayName("It should get the list of transactions for a given merchant account with pagination cursor")
+    public void shouldGetTransactionsWithPaginationCursor() {
+        String jsonResponseFile = "merchant_accounts/200.get_transactions.json";
+        RequestStub.New()
+                .method("post")
+                .path(urlPathEqualTo("/connect/token"))
+                .status(200)
+                .bodyFile("auth/200.access_token.json")
+                .build();
+        RequestStub.New()
+                .method("get")
+                .path(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withAuthorization()
+                .status(200)
+                .bodyFile(jsonResponseFile)
+                .build();
+
+        String from = "2022-01-01T00:00:00Z";
+        String to = "2022-03-01T00:00:00Z";
+        String cursor = UUID.randomUUID().toString();
+        ListTransactionsQuery query = ListTransactionsQuery.builder()
+                .from(ZonedDateTime.parse(from))
+                .to(ZonedDateTime.parse(to))
+                .type(TransactionTypeQuery.PAYMENT)
+                .cursor(cursor)
+                .build();
+        ApiResponse<ListTransactionsResponse> response = tlClient.merchantAccounts()
+                .listTransactions(A_MERCHANT_ACCOUNT_ID, query)
+                .get();
+
+        verifyGeneratedToken(Collections.singletonList(PAYMENTS));
+        verify(getRequestedFor(urlPathEqualTo("/merchant-accounts/" + A_MERCHANT_ACCOUNT_ID + "/transactions"))
+                .withQueryParam("from", equalTo(to))
+                .withQueryParam("from", equalTo(from))
+                .withQueryParam("type", equalTo(TransactionTypeQuery.PAYMENT.toString()))
+                .withQueryParam("cursor", equalTo(cursor)));
+
         assertNotError(response);
         ListTransactionsResponse expected = deserializeJsonFileTo(jsonResponseFile, ListTransactionsResponse.class);
         assertEquals(expected, response.getData());

--- a/src/test/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandlerTests.java
+++ b/src/test/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandlerTests.java
@@ -96,6 +96,7 @@ class MerchantAccountsHandlerTests {
         verify(merchantAccountsApiMock, times(1))
                 .listTransactions(
                         SCOPES,
+                        emptyMap(),
                         A_MERCHANT_ACCOUNT_ID,
                         DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(from),
                         DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(to),
@@ -166,26 +167,18 @@ class MerchantAccountsHandlerTests {
 
     private static Stream<Arguments> provideFromAndToParameters() {
         return Stream.of(
-                Arguments.of(
-                        ZonedDateTime.now(),
-                        ZonedDateTime.now().plusMonths(-12),
-                        "a-cursor"
-                ),
+                Arguments.of(ZonedDateTime.now(), ZonedDateTime.now().plusMonths(-12), "a-cursor"),
                 Arguments.of(
                         ZonedDateTime.now(ZoneId.of("Europe/Paris")),
                         ZonedDateTime.now(ZoneId.of("Europe/Paris")).plusMonths(-12),
-                        UUID.randomUUID().toString()
-                ),
+                        UUID.randomUUID().toString()),
                 Arguments.of(
                         ZonedDateTime.of(LocalDate.of(2021, 3, 1), LocalTime.MIN, ZoneId.of("UTC")),
                         ZonedDateTime.of(LocalDate.of(2022, 3, 1), LocalTime.MIN, ZoneId.of("UTC")),
-                        "another-cursor"
-                ),
+                        "another-cursor"),
                 Arguments.of(
                         ZonedDateTime.parse("2021-03-01T00:00:00Z"),
                         ZonedDateTime.parse("2022-03-01T00:00:00Z"),
-                        "yet-another-cursor"
-                )
-        );
+                        "yet-another-cursor"));
     }
 }

--- a/src/test/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandlerTests.java
+++ b/src/test/java/com/truelayer/java/merchantaccounts/MerchantAccountsHandlerTests.java
@@ -19,6 +19,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -80,13 +81,14 @@ class MerchantAccountsHandlerTests {
     }
 
     @DisplayName("It should call the list transactions endpoint")
-    @ParameterizedTest(name = "with from={0} and to={1}")
+    @ParameterizedTest(name = "with from={0}, to={1} and cursor={2}")
     @MethodSource("provideFromAndToParameters")
-    public void shouldCallListTransactionsEndpoint(ZonedDateTime from, ZonedDateTime to) {
+    public void shouldCallListTransactionsEndpoint(ZonedDateTime from, ZonedDateTime to, String cursor) {
         ListTransactionsQuery query = ListTransactionsQuery.builder()
                 .from(from)
                 .to(to)
                 .type(TransactionTypeQuery.PAYOUT)
+                .cursor(cursor)
                 .build();
 
         sut.listTransactions(A_MERCHANT_ACCOUNT_ID, query);
@@ -97,7 +99,8 @@ class MerchantAccountsHandlerTests {
                         A_MERCHANT_ACCOUNT_ID,
                         DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(from),
                         DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(to),
-                        query.type());
+                        query.type(),
+                        query.cursor());
     }
 
     @Test
@@ -163,13 +166,26 @@ class MerchantAccountsHandlerTests {
 
     private static Stream<Arguments> provideFromAndToParameters() {
         return Stream.of(
-                Arguments.of(ZonedDateTime.now(), ZonedDateTime.now().plusMonths(-12)),
+                Arguments.of(
+                        ZonedDateTime.now(),
+                        ZonedDateTime.now().plusMonths(-12),
+                        "a-cursor"
+                ),
                 Arguments.of(
                         ZonedDateTime.now(ZoneId.of("Europe/Paris")),
-                        ZonedDateTime.now(ZoneId.of("Europe/Paris")).plusMonths(-12)),
+                        ZonedDateTime.now(ZoneId.of("Europe/Paris")).plusMonths(-12),
+                        UUID.randomUUID().toString()
+                ),
                 Arguments.of(
                         ZonedDateTime.of(LocalDate.of(2021, 3, 1), LocalTime.MIN, ZoneId.of("UTC")),
-                        ZonedDateTime.of(LocalDate.of(2022, 3, 1), LocalTime.MIN, ZoneId.of("UTC"))),
-                Arguments.of(ZonedDateTime.parse("2021-03-01T00:00:00Z"), ZonedDateTime.parse("2022-03-01T00:00:00Z")));
+                        ZonedDateTime.of(LocalDate.of(2022, 3, 1), LocalTime.MIN, ZoneId.of("UTC")),
+                        "another-cursor"
+                ),
+                Arguments.of(
+                        ZonedDateTime.parse("2021-03-01T00:00:00Z"),
+                        ZonedDateTime.parse("2022-03-01T00:00:00Z"),
+                        "yet-another-cursor"
+                )
+        );
     }
 }

--- a/src/test/resources/__files/merchant_accounts/200.get_transactions.json
+++ b/src/test/resources/__files/merchant_accounts/200.get_transactions.json
@@ -165,5 +165,8 @@
       "refund_id":"an-id",
       "payment_id":"another-id"
     }
-  ]
+  ],
+  "pagination": {
+    "next_cursor": "MjAyMi0wNC0xM1QxNjoxNzoyOS4zMzJaLDZhZWI2MjZmLWM4MGQtNDUzOC05NjAwLTQ2MzUyZDhjN2Q4NA=="
+  }
 }


### PR DESCRIPTION
# Description

Adds support for paginating merchant accounts transactions. 
If not enabled at their client setting already, clients created before December 2023 have to explicitly opt-in with the help of an HTTP header [as described on our public API documentation](https://docs.truelayer.com/docs/enable-pagination-transactions-endpoint#enable-pagination).

To do so, when using the Java library, those clients can use a new overload of the `listTransactions` API accepts an extra headers parameter:

```java
// Clients created before December 2023
tlClient.merchantAccounts()
    .listTransactions(
            Headers.builder()
                    .enablePagination() //required to opt-in for pagination
                    .build(), 
            getMerchantAccount(CurrencyCode.GBP).getId(),
            ListTransactionsQuery.builder().from(from).to(to).build())
    .get();
```

Clients created from December 2023 onwards can use the existing, simpler variation of the `listTransactions` API:
```java
// Clients created from December 2023
tlClient.merchantAccounts()
    .listTransactions(
            getMerchantAccount(CurrencyCode.GBP).getId(),
            ListTransactionsQuery.builder().from(from).to(to).build())
    .get();
```




> [!IMPORTANT]  
> Note that for clients created before December 2023 that **do not** explicitly opt-in for the pagination feature, the use of the cursor `query` parameter will be ineffective, and the `pagination` object in returned responses will be always null.

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation