### PR TITLE
[EWT-539] Update provider availability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=11.1.0
+version=12.0.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/entities/ProviderAvailability.java
+++ b/src/main/java/com/truelayer/java/entities/ProviderAvailability.java
@@ -12,6 +12,5 @@ import lombok.ToString;
 @ToString
 public class ProviderAvailability {
     AvailabilityRecommendedStatus recommendedStatus;
-    float errorRate;
     ZonedDateTime updatedAt;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/BankTransferCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/BankTransferCapabilities.java
@@ -1,5 +1,6 @@
 package com.truelayer.java.paymentsproviders.entities;
 
+import com.truelayer.java.entities.ProviderAvailability;
 import com.truelayer.java.payments.entities.ReleaseChannel;
 import java.util.List;
 import lombok.Value;
@@ -9,4 +10,6 @@ public class BankTransferCapabilities {
     ReleaseChannel releaseChannel;
 
     List<Scheme> schemes;
+
+    ProviderAvailability availability;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpCommercialCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpCommercialCapabilities.java
@@ -7,5 +7,6 @@ import lombok.Value;
 @Value
 public class VrpCommercialCapabilities {
     ReleaseChannel releaseChannel;
+    
     ProviderAvailability availability;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpCommercialCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpCommercialCapabilities.java
@@ -7,6 +7,6 @@ import lombok.Value;
 @Value
 public class VrpCommercialCapabilities {
     ReleaseChannel releaseChannel;
-    
+
     ProviderAvailability availability;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpCommercialCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpCommercialCapabilities.java
@@ -1,9 +1,11 @@
 package com.truelayer.java.paymentsproviders.entities;
 
+import com.truelayer.java.entities.ProviderAvailability;
 import com.truelayer.java.payments.entities.ReleaseChannel;
 import lombok.Value;
 
 @Value
 public class VrpCommercialCapabilities {
     ReleaseChannel releaseChannel;
+    ProviderAvailability availability;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpSweepingCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/VrpSweepingCapabilities.java
@@ -1,9 +1,12 @@
 package com.truelayer.java.paymentsproviders.entities;
 
+import com.truelayer.java.entities.ProviderAvailability;
 import com.truelayer.java.payments.entities.ReleaseChannel;
 import lombok.Value;
 
 @Value
 public class VrpSweepingCapabilities {
     ReleaseChannel releaseChannel;
+
+    ProviderAvailability availability;
 }

--- a/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.provider_selection.json
+++ b/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.provider_selection.json
@@ -13,7 +13,6 @@
             "country_code":"GB",
             "availability": {
               "recommended_status":"healthy",
-              "error_rate":0.1,
               "updated_at":"2022-01-17T17:13:18.214924Z"
             },
             "search_aliases": ["firstalias", "anotheralias"]

--- a/src/test/resources/__files/payments_providers/200.get_payments_provider.json
+++ b/src/test/resources/__files/payments_providers/200.get_payments_provider.json
@@ -9,6 +9,10 @@
     "payments": {
       "bank_transfer": {
         "release_channel": "general_availability",
+        "availability": {
+          "recommended_status":"healthy",
+          "updated_at":"2024-04-16T14:11:18.214924Z"
+        },
         "schemes": [
           {
             "id": "faster_payments_service"

--- a/src/test/resources/__files/payments_providers/200.get_payments_provider.json
+++ b/src/test/resources/__files/payments_providers/200.get_payments_provider.json
@@ -22,7 +22,18 @@
     },
     "mandates": {
       "vrp_sweeping": {
-        "release_channel": "general_availability"
+        "release_channel": "general_availability",
+        "availability": {
+          "recommended_status":"healthy",
+          "updated_at":"2024-04-16T14:11:18.214924Z"
+        }
+      },
+      "vrp_commercial": {
+        "release_channel": "general_availability",
+        "availability": {
+          "recommended_status":"healthy",
+          "updated_at":"2024-04-16T14:11:18.214924Z"
+        }
       }
     }
   }


### PR DESCRIPTION
# Description

- Add `capabilities.payments.bankTransfer.availability` field to payments provider response entity 
- Add `capabilities.mandates.vrpSweeping.availability` field to payments provider response entity
- Add `capabilities.mandates.vrpCommercial.availability` field to payments provider response entity
- Update `ProviderAvailability` object removing `errorRate` field

Fixes [EWT-539](https://truelayer.atlassian.net/browse/EWT-539)

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation

[EWT-539]: https://truelayer.atlassian.net/browse/EWT-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ