### PR TITLE
fix(EWT-543): type change for description field in authorization flow actions objects

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=12.0.0
+version=13.0.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/forminput/Input.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/forminput/Input.java
@@ -21,7 +21,7 @@ public abstract class Input {
     String id;
     boolean mandatory;
     DisplayText displayText;
-    String description;
+    DisplayText description;
 
     @JsonIgnore
     public boolean isText() {

--- a/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.form.json
+++ b/src/test/resources/__files/payments/200.start_authorization_flow.authorizing.form.json
@@ -12,7 +12,10 @@
               "key": "text_input_1.display_text",
               "default": "Text input 1"
             },
-            "description": "some description",
+            "description": {
+              "key": "a-key",
+              "default": "some text"
+            },
             "format": "alphanumerical",
             "sensitive": true,
             "min_length": 5,
@@ -35,7 +38,10 @@
               "key": "text_with_image_input_1.display_text",
               "default": "Text with image input 1"
             },
-            "description": "some description",
+            "description": {
+              "key": "a-key",
+              "default": "some text"
+            },
             "format": "alphanumerical",
             "sensitive": true,
             "min_length": 5,
@@ -63,7 +69,10 @@
               "key": "select_input_1.display_text",
               "default": "Select input 1"
             },
-            "description": "some description",
+            "description": {
+              "key": "a-key",
+              "default": "some text"
+            },
             "options": [
               {
                 "id": "option_1",


### PR DESCRIPTION
# Description

> [!WARNING]  
> This is a breaking change from the library perspective. 

Fixes a long time oversight: the description field in form actions objects was implemented as `String`, but it's of type `DisplayText`. 

Unfortunately this is a breaking change at compilation time.

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation