### PR TITLE
Adjust settlement/authorisation timeouts in acceptance tests, and review version info loader implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,6 @@ dependencies {
     // Utilities
     implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.10.1'
 
-
     // HTTP client
     def retrofitVersion = '2.9.0'
     implementation group: 'com.squareup.retrofit2', name: 'retrofit', version: retrofitVersion

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ tasks.register('acceptance-tests', Test) {
 
 dependencies {
     // Utilities
-    implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.10.1'
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=13.0.1
+version=13.0.2
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/versioninfo/LibraryInfoLoader.java
+++ b/src/main/java/com/truelayer/java/versioninfo/LibraryInfoLoader.java
@@ -1,10 +1,13 @@
 package com.truelayer.java.versioninfo;
 
+import static java.util.Objects.requireNonNull;
+
 import com.truelayer.java.Constants;
 import com.truelayer.java.TrueLayerException;
-import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.builder.fluent.Configurations;
-import org.apache.commons.configuration2.ex.ConfigurationException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
 
 /**
  * Class the loads the version of the library during the client initialization.
@@ -15,18 +18,23 @@ public class LibraryInfoLoader {
     private static final String CONFIG_FILE_PREXIF = "truelayer-java";
 
     public VersionInfo load() {
-        PropertiesConfiguration libraryVersionProps = getVersionInfoPropertiesFile();
+        Properties libraryVersionProps = getVersionInfoProperties();
 
         return VersionInfo.builder()
-                .libraryName(libraryVersionProps.getString(Constants.VersionInfo.NAME))
-                .libraryVersion(libraryVersionProps.getString(Constants.VersionInfo.VERSION))
+                .libraryName(libraryVersionProps.getProperty(Constants.VersionInfo.NAME))
+                .libraryVersion(libraryVersionProps.getProperty(Constants.VersionInfo.VERSION))
                 .build();
     }
 
-    private PropertiesConfiguration getVersionInfoPropertiesFile() {
+    private Properties getVersionInfoProperties() {
         try {
-            return new Configurations().properties(CONFIG_FILE_PREXIF + "." + "version" + ".properties");
-        } catch (ConfigurationException e) {
+            Properties versionInfoProps = new Properties();
+            versionInfoProps.load(Files.newInputStream(Paths.get(requireNonNull(getClass()
+                            .getClassLoader()
+                            .getResource(CONFIG_FILE_PREXIF + "." + "version" + ".properties"))
+                    .getPath())));
+            return versionInfoProps;
+        } catch (IOException e) {
             throw new TrueLayerException("Unable to load library version file", e);
         }
     }

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -486,7 +486,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
     private void waitForMandateToBeAuthorized(String mandateId) {
         await().with()
                 .pollInterval(1, TimeUnit.SECONDS)
-                .atMost(5, TimeUnit.SECONDS)
+                .atMost(30, TimeUnit.SECONDS)
                 .until(() -> {
                     // get mandate by id
                     ApiResponse<MandateDetail> getMandateResponse =

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -569,7 +569,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                     }
                 })
                 .pollInterval(1, TimeUnit.SECONDS)
-                .atMost(15, TimeUnit.SECONDS)
+                .atMost(30, TimeUnit.SECONDS)
                 .until(() -> {
                     // get payment by id
                     ApiResponse<PaymentDetail> getPaymentResponse =


### PR DESCRIPTION
# Description

1. Raises settlement and authorisation timeouts in our acceptance tests to reduce pointless noise on our reporting channels
2. reviews implementation of the Version info loader class to remove the dependencies on the beanutils package

Fixes EWT-561 and EWT-390

## Type of change

Please select multiple options if required.

- [x] KTLO
- [x] Proactive maintenance

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation