### PR TITLE
[EWT-590] Fix mandates acceptance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=13.0.4
+version=13.0.5
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -174,7 +174,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getUri();
         runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
 
-        waitForMandateToBeAuthorized(createMandateResponse.getData().getId());
+        waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
         // finally make a confirmation of funds request for 1 penny
         ApiResponse<GetConfirmationOfFundsResponse> getConfirmationOfFundsResponseApiResponse = tlClient.mandates()
@@ -231,7 +231,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getUri();
         runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
 
-        waitForMandateToBeAuthorized(createMandateResponse.getData().getId());
+        waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
         // finally make a Get constraints request
         ApiResponse<GetConstraintsResponse> getConstraintsResponseApiResponse = tlClient.mandates()
@@ -278,7 +278,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getUri();
         runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
 
-        waitForMandateToBeAuthorized(createMandateResponse.getData().getId());
+        waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
         // revoke mandate by id
         ApiResponse<Void> revokeMandateResponse = tlClient.mandates()
@@ -333,7 +333,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getUri();
         runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
 
-        waitForMandateToBeAuthorized(createMandateResponse.getData().getId());
+        waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
         // get mandate by id
         ApiResponse<MandateDetail> getMandateResponse = tlClient.mandates()
@@ -483,7 +483,7 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
         assertTrue(submitProviderParamsResponse.isSuccessful());
     }
 
-    private void waitForMandateToBeAuthorized(String mandateId) {
+    private void waitForMandateToBeAuthorized(TrueLayerClient tlClient, String mandateId) {
         await().with()
                 .pollInterval(1, TimeUnit.SECONDS)
                 .atMost(30, TimeUnit.SECONDS)


### PR DESCRIPTION
# Description

In mandates acceptance tests, we have some testing scenario requiring us to wait and poll a mandate until it reaches a certain status, before proceeding with assertions and/or other operations. 

The method taking care of this polling operation was using by mistake the `tlClient` built in the base class, which uses default scopes: as a result, we were invoking the GET /mandates endpoint always using the `recurring_payments:sweeping` scope (the default if not set explicitly when building the client), and this was causing calls related to cVRP mandates to fail (a `recurring_payments:commercial` scope is expected in this case). 

This PR will fix the bug, that went unnoticed for some time until a stricter check on scopes had been introduced by PGW (PR [here](https://github.com/TrueLayer/payments-gateway/pull/1079) for reference)

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation