### PR TITLE
[ACL-138] Add support for retry parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation group: 'com.squareup.retrofit2', name: 'converter-jackson', version: retrofitVersion
 
     // TL signing library
-    implementation group: 'com.truelayer', name: 'truelayer-signing', version: '0.2.5'
+    implementation group: 'com.truelayer', name: 'truelayer-signing', version: '0.2.6'
 
     // Serialization
     def jacksonVersion = '2.14.1'

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
 
     // Mocking libraries
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.12.0'
-    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.6.0'
+    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.9.0'
 
     // Wait test utility
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     implementation group: 'org.tinylog', name: 'tinylog-impl', version: tinyLogVersion
 
     // JUnit test framework.
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.10.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.10.3'
 
     // Mocking libraries
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ tasks.register('acceptance-tests', Test) {
 
 dependencies {
     // Utilities
-    implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.10.1'
+    implementation group: 'org.apache.commons', name: 'commons-configuration2', version: '2.11.0'
 
     // HTTP client
     def retrofitVersion = '2.9.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=13.0.5
+version=13.1.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/entities/Configuration.java
+++ b/src/main/java/com/truelayer/java/entities/Configuration.java
@@ -2,9 +2,8 @@ package com.truelayer.java.entities;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.truelayer.java.payments.entities.paymentdetail.RedirectStatus;
-import lombok.Value;
-
 import java.util.Optional;
+import lombok.Value;
 
 @Value
 public class Configuration {

--- a/src/main/java/com/truelayer/java/entities/Configuration.java
+++ b/src/main/java/com/truelayer/java/entities/Configuration.java
@@ -1,7 +1,10 @@
 package com.truelayer.java.entities;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.truelayer.java.payments.entities.paymentdetail.RedirectStatus;
 import lombok.Value;
+
+import java.util.Optional;
 
 @Value
 public class Configuration {
@@ -9,8 +12,15 @@ public class Configuration {
 
     RedirectStatus redirect;
 
+    Retry retry;
+
     @Value
     public static class ProviderSelection {
         ConfigurationStatus status;
+    }
+
+    @JsonGetter
+    public Optional<Retry> getRetry() {
+        return Optional.ofNullable(retry);
     }
 }

--- a/src/main/java/com/truelayer/java/entities/Retry.java
+++ b/src/main/java/com/truelayer/java/entities/Retry.java
@@ -1,0 +1,6 @@
+package com.truelayer.java.entities;
+
+import lombok.Value;
+
+@Value
+public class Retry {}

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AttemptFailedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AttemptFailedPaymentDetail.java
@@ -1,0 +1,45 @@
+package com.truelayer.java.payments.entities.paymentdetail;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
+import com.truelayer.java.entities.PaymentSource;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class AttemptFailedPaymentDetail extends PaymentDetail {
+
+    Status status = Status.ATTEMPT_FAILED;
+
+    PaymentSource paymentSource;
+
+    ZonedDateTime failedAt;
+
+    FailureStage failureStage;
+
+    String failureReason;
+
+    AuthorizationFlowWithConfiguration authorizationFlow;
+
+    @JsonGetter
+    public Optional<AuthorizationFlowWithConfiguration> getAuthorizationFlow() {
+        return Optional.ofNullable(authorizationFlow);
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum FailureStage {
+        AUTHORIZING("authorizing"),
+        AUTHORIZED("authorized");
+
+        @JsonValue
+        private final String failureStage;
+    }
+}

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AttemptFailedPaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AttemptFailedPaymentDetail.java
@@ -4,13 +4,12 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.truelayer.java.entities.AuthorizationFlowWithConfiguration;
 import com.truelayer.java.entities.PaymentSource;
+import java.time.ZonedDateTime;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
-
-import java.time.ZonedDateTime;
-import java.util.Optional;
 
 @Value
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowAction.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowAction.java
@@ -16,7 +16,8 @@ import lombok.ToString;
     @JsonSubTypes.Type(value = Consent.class, name = "consent"),
     @JsonSubTypes.Type(value = Form.class, name = "form"),
     @JsonSubTypes.Type(value = WaitForOutcome.class, name = "wait"),
-    @JsonSubTypes.Type(value = Redirect.class, name = "redirect")
+    @JsonSubTypes.Type(value = Redirect.class, name = "redirect"),
+    @JsonSubTypes.Type(value = Retry.class, name = "retry")
 })
 @ToString
 @EqualsAndHashCode
@@ -49,6 +50,11 @@ public abstract class AuthorizationFlowAction {
     @JsonIgnore
     public boolean isRedirect() {
         return this instanceof Redirect;
+    }
+
+    @JsonIgnore
+    public boolean isRetry() {
+        return this instanceof Retry;
     }
 
     public ProviderSelection asProviderSelection() {
@@ -86,6 +92,13 @@ public abstract class AuthorizationFlowAction {
         return (Redirect) this;
     }
 
+    public Retry asRetry() {
+        if (!isRetry()) {
+            throw new TrueLayerException(buildErrorMessage());
+        }
+        return (Retry) this;
+    }
+
     private String buildErrorMessage() {
         return String.format(
                 "Authorization flow is of type %s.", this.getClass().getSimpleName());
@@ -98,7 +111,8 @@ public abstract class AuthorizationFlowAction {
         CONSENT("consent"),
         FORM("form"),
         REDIRECT("redirect"),
-        WAIT("wait");
+        WAIT("wait"),
+        RETRY("retry");
 
         @JsonValue
         private final String type;

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetail.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetail.java
@@ -17,7 +17,8 @@ import lombok.*;
     @JsonSubTypes.Type(value = AuthorizedPaymentDetail.class, name = "authorized"),
     @JsonSubTypes.Type(value = FailedPaymentDetail.class, name = "failed"),
     @JsonSubTypes.Type(value = SettledPaymentDetail.class, name = "settled"),
-    @JsonSubTypes.Type(value = ExecutedPaymentDetail.class, name = "executed")
+    @JsonSubTypes.Type(value = ExecutedPaymentDetail.class, name = "executed"),
+    @JsonSubTypes.Type(value = AttemptFailedPaymentDetail.class, name = "attempt_failed")
 })
 @Getter
 public abstract class PaymentDetail {
@@ -69,6 +70,11 @@ public abstract class PaymentDetail {
     }
 
     @JsonIgnore
+    public boolean isAttemptFailed() {
+        return this instanceof AttemptFailedPaymentDetail;
+    }
+
+    @JsonIgnore
     public AuthorizationRequiredPaymentDetail asAuthorizationRequired() {
         if (!isAuthorizationRequired()) {
             throw new TrueLayerException(buildErrorMessage());
@@ -114,6 +120,14 @@ public abstract class PaymentDetail {
             throw new TrueLayerException(buildErrorMessage());
         }
         return (SettledPaymentDetail) this;
+    }
+
+    @JsonIgnore
+    public AttemptFailedPaymentDetail asAttemptFailed() {
+        if (!isAttemptFailed()) {
+            throw new TrueLayerException(buildErrorMessage());
+        }
+        return (AttemptFailedPaymentDetail) this;
     }
 
     private String buildErrorMessage() {

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Retry.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Retry.java
@@ -1,0 +1,14 @@
+package com.truelayer.java.payments.entities.paymentdetail;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class Retry extends AuthorizationFlowAction {
+    Type type = Type.RETRY;
+
+    List<String> retryOptions;
+}

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Retry.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Retry.java
@@ -9,5 +9,5 @@ import lombok.Value;
 public class Retry extends AuthorizationFlowAction {
     Type type = Type.RETRY;
 
-    List<String> retryOptions;
+    List<RetryOption> retryOptions;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Retry.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Retry.java
@@ -1,9 +1,8 @@
 package com.truelayer.java.payments.entities.paymentdetail;
 
+import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-
-import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/RetryOption.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/RetryOption.java
@@ -1,0 +1,14 @@
+package com.truelayer.java.payments.entities.paymentdetail;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum RetryOption {
+    RESTART("restart");
+
+    @JsonValue
+    private final String option;
+}

--- a/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Status.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentdetail/Status.java
@@ -12,7 +12,8 @@ public enum Status {
     AUTHORIZED("authorized"),
     EXECUTED("executed"),
     FAILED("failed"),
-    SETTLED("settled");
+    SETTLED("settled"),
+    ATTEMPT_FAILED("attempt_failed");
 
     @JsonValue
     private final String status;

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/BankTransfer.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/BankTransfer.java
@@ -6,10 +6,9 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.truelayer.java.entities.Retry;
 import com.truelayer.java.payments.entities.beneficiary.Beneficiary;
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.Optional;
 
 @Builder
 @Getter

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/BankTransfer.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/BankTransfer.java
@@ -2,10 +2,14 @@ package com.truelayer.java.payments.entities.paymentmethod;
 
 import static com.truelayer.java.payments.entities.paymentmethod.PaymentMethod.Type.BANK_TRANSFER;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.truelayer.java.entities.Retry;
 import com.truelayer.java.payments.entities.beneficiary.Beneficiary;
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.Optional;
 
 @Builder
 @Getter
@@ -15,4 +19,11 @@ public class BankTransfer extends PaymentMethod {
     private ProviderSelection providerSelection;
 
     private Beneficiary beneficiary;
+
+    private Retry retry;
+
+    @JsonGetter
+    public Optional<Retry> getRetry() {
+        return Optional.ofNullable(retry);
+    }
 }

--- a/src/test/java/com/truelayer/java/TestUtils.java
+++ b/src/test/java/com/truelayer/java/TestUtils.java
@@ -23,7 +23,6 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.regex.Pattern;
-
 import lombok.*;
 import okhttp3.*;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -308,11 +307,13 @@ public class TestUtils {
         String payload;
 
         @Builder
-        public static HeadlessResourceAuthorization newHeadlessResourceAuthorization(HeadlessResource resource, HeadlessResourceAction action) {
-            HeadlessResourceAuthorization testHeadlessResourceAuthorization = new HeadlessResourceAuthorization(action, resource);
-            testHeadlessResourceAuthorization.payload = String.format("{\"action\":\"%s\", \"redirect\": false}", action.getAction());
-            switch (resource)
-            {
+        public static HeadlessResourceAuthorization newHeadlessResourceAuthorization(
+                HeadlessResource resource, HeadlessResourceAction action) {
+            HeadlessResourceAuthorization testHeadlessResourceAuthorization =
+                    new HeadlessResourceAuthorization(action, resource);
+            testHeadlessResourceAuthorization.payload =
+                    String.format("{\"action\":\"%s\", \"redirect\": false}", action.getAction());
+            switch (resource) {
                 case PAYMENTS:
                     testHeadlessResourceAuthorization.path = "single-immediate-payments";
                     break;

--- a/src/test/java/com/truelayer/java/TestUtils.java
+++ b/src/test/java/com/truelayer/java/TestUtils.java
@@ -301,10 +301,10 @@ public class TestUtils {
     @RequiredArgsConstructor
     @Getter
     public static class HeadlessResourceAuthorization {
-        final HeadlessResourceAction action;
-        final HeadlessResource resource;
-        String path;
-        String payload;
+        private final HeadlessResourceAction action;
+        private final HeadlessResource resource;
+        private String path;
+        private String payload;
 
         @Builder
         public static HeadlessResourceAuthorization newHeadlessResourceAuthorization(

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -172,10 +172,13 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.AUTHORISE)
-                .resource(HeadlessResource.MANDATES)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.AUTHORISE)
+                        .resource(HeadlessResource.MANDATES)
+                        .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
@@ -232,10 +235,13 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.AUTHORISE)
-                .resource(HeadlessResource.MANDATES)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.AUTHORISE)
+                        .resource(HeadlessResource.MANDATES)
+                        .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
@@ -282,10 +288,13 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.AUTHORISE)
-                .resource(HeadlessResource.MANDATES)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.AUTHORISE)
+                        .resource(HeadlessResource.MANDATES)
+                        .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
@@ -340,10 +349,13 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.AUTHORISE)
-                .resource(HeadlessResource.MANDATES)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.AUTHORISE)
+                        .resource(HeadlessResource.MANDATES)
+                        .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 

--- a/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/MandatesAcceptanceTests.java
@@ -172,7 +172,10 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.AUTHORISE)
+                .resource(HeadlessResource.MANDATES)
+                .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
@@ -229,7 +232,10 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.AUTHORISE)
+                .resource(HeadlessResource.MANDATES)
+                .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
@@ -276,7 +282,10 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.AUTHORISE)
+                .resource(HeadlessResource.MANDATES)
+                .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 
@@ -331,7 +340,10 @@ public class MandatesAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.MANDATES);
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.AUTHORISE)
+                .resource(HeadlessResource.MANDATES)
+                .build());
 
         waitForMandateToBeAuthorized(tlClient, createMandateResponse.getData().getId());
 

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -1,14 +1,27 @@
 package com.truelayer.java.acceptance;
 
+import static com.truelayer.java.Constants.Scopes.PAYMENTS;
 import static com.truelayer.java.TestUtils.*;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.truelayer.java.*;
+import com.truelayer.java.auth.AuthenticationHandler;
+import com.truelayer.java.auth.IAuthenticationHandler;
 import com.truelayer.java.entities.*;
 import com.truelayer.java.entities.Address;
 import com.truelayer.java.entities.accountidentifier.AccountIdentifier;
 import com.truelayer.java.entities.accountidentifier.SortCodeAccountNumberAccountIdentifier;
+import com.truelayer.java.http.RetrofitFactory;
+import com.truelayer.java.http.auth.AccessTokenManager;
 import com.truelayer.java.http.entities.ApiResponse;
+import com.truelayer.java.http.interceptors.AuthenticationInterceptor;
+import com.truelayer.java.http.interceptors.IdempotencyKeyGeneratorInterceptor;
+import com.truelayer.java.http.interceptors.SignatureGeneratorInterceptor;
+import com.truelayer.java.http.interceptors.TrueLayerAgentInterceptor;
 import com.truelayer.java.merchantaccounts.entities.MerchantAccount;
 import com.truelayer.java.payments.entities.*;
 import com.truelayer.java.payments.entities.StartAuthorizationFlowRequest.Redirect;
@@ -23,11 +36,14 @@ import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import com.truelayer.java.payments.entities.providerselection.UserSelectedProviderSelection;
 import com.truelayer.java.payments.entities.schemeselection.SchemeSelection;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import lombok.SneakyThrows;
+
+import com.truelayer.java.versioninfo.LibraryInfoLoader;
+import lombok.*;
 import okhttp3.*;
 import org.apache.commons.lang3.RandomUtils;
 import org.awaitility.core.*;
@@ -96,7 +112,8 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                         CurrencyCode.GBP,
                         RelatedProducts.builder()
                                 .signupPlus(Collections.emptyMap())
-                                .build()))
+                                .build(),
+                        null))
                 .get();
 
         assertNotError(createPaymentResponse);
@@ -354,7 +371,49 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.PAYMENTS);
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.EXECUTE)
+                .resource(HeadlessResource.PAYMENTS)
+                .build());
+    }
+
+    @SneakyThrows
+    @Test
+    @DisplayName("It should return attempt failed payment status if authorization is rejected with retry")
+    public void shouldReturnAttemptFailedPaymentStatusIfAuthorizationIsRejectedWithRetry() {
+        // create payment
+        CreatePaymentRequest paymentRequest =
+                buildPaymentRequestWithProviderSelectionWithRetry(buildPreselectedProviderSelection(), CurrencyCode.GBP);
+
+        ApiResponse<CreatePaymentResponse> createPaymentResponse =
+                tlClient.payments().createPayment(paymentRequest).get();
+
+        assertNotError(createPaymentResponse);
+        assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
+
+        // start the auth flow
+        AuthorizationFlowResponse startAuthorizationFlowResponse = startAuthorizationFlowWithRetry(createPaymentResponse.getData().getId());
+        URI redirectUri = startAuthorizationFlowResponse
+                .asAuthorizing()
+                .getAuthorizationFlow()
+                .getActions()
+                .getNext()
+                .asRedirect()
+                .getUri();
+
+        // use specific action to get the authorization to be rejected
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.REJECT_AUTHORISATION)
+                .resource(HeadlessResource.PAYMENTS)
+                .build());
+
+        // get by id
+        ApiResponse<PaymentDetail> getPaymentByIdResponse = tlClient.payments()
+                .getPayment(createPaymentResponse.getData().getId())
+                .get();
+
+        assertNotError(getPaymentByIdResponse);
+        assertTrue(getPaymentByIdResponse.getData().isAttemptFailed());
     }
 
     @SneakyThrows
@@ -394,7 +453,10 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.PAYMENTS);
+        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
+                .action(HeadlessResourceAction.EXECUTE)
+                .resource(HeadlessResource.PAYMENTS)
+                .build());
 
         waitForPaymentToBeSettled(paymentId);
 
@@ -488,17 +550,23 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
 
     private CreatePaymentRequest buildPaymentRequestWithProviderSelection(
             ProviderSelection providerSelection, CurrencyCode currencyCode) {
-        return buildPaymentRequestWithProviderSelection(providerSelection, currencyCode, null);
+        return buildPaymentRequestWithProviderSelection(providerSelection, currencyCode, null, null);
+    }
+
+    private CreatePaymentRequest buildPaymentRequestWithProviderSelectionWithRetry(
+            ProviderSelection providerSelection, CurrencyCode currencyCode) {
+        return buildPaymentRequestWithProviderSelection(providerSelection, currencyCode, null, new Retry());
     }
 
     private CreatePaymentRequest buildPaymentRequestWithProviderSelection(
-            ProviderSelection providerSelection, CurrencyCode currencyCode, RelatedProducts relatedProducts) {
+            ProviderSelection providerSelection, CurrencyCode currencyCode, RelatedProducts relatedProducts, Retry retry) {
         CreatePaymentRequest.CreatePaymentRequestBuilder builder = CreatePaymentRequest.builder()
                 .amountInMinor(RandomUtils.nextInt(50, 500))
                 .currency(currencyCode)
                 .paymentMethod(PaymentMethod.bankTransfer()
                         .providerSelection(providerSelection)
                         .beneficiary(buildBeneficiary(currencyCode))
+                        .retry(retry)
                         .build())
                 .user(User.builder()
                         .name("Andrea Di Lisio")
@@ -578,4 +646,77 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                     return getPaymentResponse.getData().getStatus().equals(Status.SETTLED);
                 });
     }
+
+    // since the StartAuthorizationFlowRequest object does not support retry property
+    // we need to do a raw HTTP call with a JSON string request body
+    @SneakyThrows
+    private static AuthorizationFlowResponse startAuthorizationFlowWithRetry(String paymentId) {
+
+        // build HTTP Client with required interceptors for auth token, signature etc.
+        OkHttpClient baseHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(new IdempotencyKeyGeneratorInterceptor())
+                .build();
+
+        SigningOptions signingOptions = SigningOptions.builder()
+                .keyId(System.getenv("TL_SIGNING_KEY_ID"))
+                .privateKey(System.getenv("TL_SIGNING_PRIVATE_KEY").getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        ClientCredentials clientCredentials = ClientCredentials.builder()
+                .clientId(System.getenv("TL_CLIENT_ID"))
+                .clientSecret(System.getenv("TL_CLIENT_SECRET"))
+                .build();
+
+        IAuthenticationHandler authenticationHandler = AuthenticationHandler.New()
+                .clientCredentials(clientCredentials)
+                .httpClient(RetrofitFactory.build(baseHttpClient, environment.getAuthApiUri()))
+                .build();
+
+        AccessTokenManager.AccessTokenManagerBuilder accessTokenManagerBuilder =
+                AccessTokenManager.builder().authenticationHandler(authenticationHandler);
+        AccessTokenManager accessTokenManager = accessTokenManagerBuilder.build();
+
+        OkHttpClient httpClient = baseHttpClient.newBuilder()
+                .addInterceptor(new TrueLayerAgentInterceptor(new LibraryInfoLoader().load()))
+                .addInterceptor(new IdempotencyKeyGeneratorInterceptor())
+                .addInterceptor(new SignatureGeneratorInterceptor(signingOptions))
+                .addInterceptor(new AuthenticationInterceptor(accessTokenManager))
+                .build();
+
+        // build base StartAuthorizationFlowRequest object
+        StartAuthorizationFlowRequest startAuthorizationFlowRequest = StartAuthorizationFlowRequest.builder()
+                .redirect(Redirect.builder()
+                        .returnUri(URI.create(RETURN_URI))
+                        .directReturnUri(URI.create(RETURN_URI))
+                        .build())
+                .withProviderSelection()
+                .build();
+
+        // serialize the base object to json and append retry object
+        ObjectMapper mapper = Utils.getObjectMapper();
+        String baseRequestJsonString = mapper.writeValueAsString(startAuthorizationFlowRequest);
+        JsonNode jsonNode = mapper.readTree(baseRequestJsonString);
+        ((ObjectNode) jsonNode).set("retry", mapper.createObjectNode());
+        String requestJsonString = mapper.writeValueAsString(jsonNode);
+
+        // build url
+        HttpUrl url = HttpUrl.parse(String.format("%s/payments/%s/authorization-flow",
+                Environment.sandbox().getPaymentsApiUri().toString(), paymentId));
+
+        RequestBody body = RequestBody.create(requestJsonString, MediaType.parse("application/json; charset=utf-8"));
+        Request request = new Request.Builder()
+                .url(Objects.requireNonNull(url))
+                .tag(RequestScopes.class, RequestScopes.builder().scope(PAYMENTS).build())
+                .post(body)
+                .build();
+
+        String responseBody;
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertTrue(response.isSuccessful());
+            assertNotNull(response.body());
+            responseBody = response.body().string();
+        }
+        return mapper.readValue(responseBody, AuthorizationFlowResponse.class);
+    }
+
 }

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -35,14 +35,13 @@ import com.truelayer.java.payments.entities.providerselection.PreselectedProvide
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import com.truelayer.java.payments.entities.providerselection.UserSelectedProviderSelection;
 import com.truelayer.java.payments.entities.schemeselection.SchemeSelection;
+import com.truelayer.java.versioninfo.LibraryInfoLoader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
-import com.truelayer.java.versioninfo.LibraryInfoLoader;
 import lombok.*;
 import okhttp3.*;
 import org.apache.commons.lang3.RandomUtils;
@@ -371,10 +370,13 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.EXECUTE)
-                .resource(HeadlessResource.PAYMENTS)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.EXECUTE)
+                        .resource(HeadlessResource.PAYMENTS)
+                        .build());
     }
 
     @SneakyThrows
@@ -382,8 +384,8 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
     @DisplayName("It should return attempt failed payment status if authorization is rejected with retry")
     public void shouldReturnAttemptFailedPaymentStatusIfAuthorizationIsRejectedWithRetry() {
         // create payment
-        CreatePaymentRequest paymentRequest =
-                buildPaymentRequestWithProviderSelectionWithRetry(buildPreselectedProviderSelection(), CurrencyCode.GBP);
+        CreatePaymentRequest paymentRequest = buildPaymentRequestWithProviderSelectionWithRetry(
+                buildPreselectedProviderSelection(), CurrencyCode.GBP);
 
         ApiResponse<CreatePaymentResponse> createPaymentResponse =
                 tlClient.payments().createPayment(paymentRequest).get();
@@ -392,7 +394,8 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
         assertTrue(createPaymentResponse.getData().isAuthorizationRequired());
 
         // start the auth flow
-        AuthorizationFlowResponse startAuthorizationFlowResponse = startAuthorizationFlowWithRetry(createPaymentResponse.getData().getId());
+        AuthorizationFlowResponse startAuthorizationFlowResponse =
+                startAuthorizationFlowWithRetry(createPaymentResponse.getData().getId());
         URI redirectUri = startAuthorizationFlowResponse
                 .asAuthorizing()
                 .getAuthorizationFlow()
@@ -402,10 +405,13 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 .getUri();
 
         // use specific action to get the authorization to be rejected
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.REJECT_AUTHORISATION)
-                .resource(HeadlessResource.PAYMENTS)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.REJECT_AUTHORISATION)
+                        .resource(HeadlessResource.PAYMENTS)
+                        .build());
 
         // get by id
         ApiResponse<PaymentDetail> getPaymentByIdResponse = tlClient.payments()
@@ -453,10 +459,13 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 .getNext()
                 .asRedirect()
                 .getUri();
-        runAndAssertHeadlessResourceAuthorisation(tlClient, redirectUri, HeadlessResourceAuthorization.builder()
-                .action(HeadlessResourceAction.EXECUTE)
-                .resource(HeadlessResource.PAYMENTS)
-                .build());
+        runAndAssertHeadlessResourceAuthorisation(
+                tlClient,
+                redirectUri,
+                HeadlessResourceAuthorization.builder()
+                        .action(HeadlessResourceAction.EXECUTE)
+                        .resource(HeadlessResource.PAYMENTS)
+                        .build());
 
         waitForPaymentToBeSettled(paymentId);
 
@@ -559,7 +568,10 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
     }
 
     private CreatePaymentRequest buildPaymentRequestWithProviderSelection(
-            ProviderSelection providerSelection, CurrencyCode currencyCode, RelatedProducts relatedProducts, Retry retry) {
+            ProviderSelection providerSelection,
+            CurrencyCode currencyCode,
+            RelatedProducts relatedProducts,
+            Retry retry) {
         CreatePaymentRequest.CreatePaymentRequestBuilder builder = CreatePaymentRequest.builder()
                 .amountInMinor(RandomUtils.nextInt(50, 500))
                 .currency(currencyCode)
@@ -676,7 +688,8 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 AccessTokenManager.builder().authenticationHandler(authenticationHandler);
         AccessTokenManager accessTokenManager = accessTokenManagerBuilder.build();
 
-        OkHttpClient httpClient = baseHttpClient.newBuilder()
+        OkHttpClient httpClient = baseHttpClient
+                .newBuilder()
                 .addInterceptor(new TrueLayerAgentInterceptor(new LibraryInfoLoader().load()))
                 .addInterceptor(new IdempotencyKeyGeneratorInterceptor())
                 .addInterceptor(new SignatureGeneratorInterceptor(signingOptions))
@@ -700,13 +713,16 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
         String requestJsonString = mapper.writeValueAsString(jsonNode);
 
         // build url
-        HttpUrl url = HttpUrl.parse(String.format("%s/payments/%s/authorization-flow",
+        HttpUrl url = HttpUrl.parse(String.format(
+                "%s/payments/%s/authorization-flow",
                 Environment.sandbox().getPaymentsApiUri().toString(), paymentId));
 
         RequestBody body = RequestBody.create(requestJsonString, MediaType.parse("application/json; charset=utf-8"));
         Request request = new Request.Builder()
                 .url(Objects.requireNonNull(url))
-                .tag(RequestScopes.class, RequestScopes.builder().scope(PAYMENTS).build())
+                .tag(
+                        RequestScopes.class,
+                        RequestScopes.builder().scope(PAYMENTS).build())
                 .post(body)
                 .build();
 
@@ -718,5 +734,4 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
         }
         return mapper.readValue(responseBody, AuthorizationFlowResponse.class);
     }
-
 }

--- a/src/test/java/com/truelayer/java/integration/PaymentsIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/PaymentsIntegrationTests.java
@@ -448,6 +448,7 @@ public class PaymentsIntegrationTests extends IntegrationTests {
                 Arguments.of(BANK_TRANSFER, EXECUTED),
                 Arguments.of(BANK_TRANSFER, SETTLED),
                 Arguments.of(BANK_TRANSFER, FAILED),
+                Arguments.of(BANK_TRANSFER, ATTEMPT_FAILED),
                 Arguments.of(MANDATE, EXECUTED),
                 Arguments.of(MANDATE, FAILED));
     }

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowActionTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowActionTests.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.truelayer.java.TrueLayerException;
 import java.net.URI;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowActionTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowActionTests.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.truelayer.java.TrueLayerException;
 import java.net.URI;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -146,6 +148,35 @@ class AuthorizationFlowActionTests {
         AuthorizationFlowAction sut = new ProviderSelection(null);
 
         Throwable thrown = assertThrows(TrueLayerException.class, sut::asRedirect);
+
+        assertEquals(
+                String.format(
+                        "Authorization flow is of type %s.", sut.getClass().getSimpleName()),
+                thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("It should yield true if instance is of type Retry")
+    public void shouldYieldTrueIfRetry() {
+        AuthorizationFlowAction sut = new Retry(List.of("restart"));
+
+        assertTrue(sut.isRetry());
+    }
+
+    @Test
+    @DisplayName("It should convert to an instance of class Retry")
+    public void shouldConvertToRetry() {
+        AuthorizationFlowAction sut = new Retry(List.of("restart"));
+
+        assertDoesNotThrow(sut::asRetry);
+    }
+
+    @Test
+    @DisplayName("It should throw an error when converting to Retry")
+    public void shouldNotConvertToRetry() {
+        AuthorizationFlowAction sut = new ProviderSelection(null);
+
+        Throwable thrown = assertThrows(TrueLayerException.class, sut::asRetry);
 
         assertEquals(
                 String.format(

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowActionTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/AuthorizationFlowActionTests.java
@@ -157,7 +157,7 @@ class AuthorizationFlowActionTests {
     @Test
     @DisplayName("It should yield true if instance is of type Retry")
     public void shouldYieldTrueIfRetry() {
-        AuthorizationFlowAction sut = new Retry(List.of("restart"));
+        AuthorizationFlowAction sut = new Retry(List.of(RetryOption.RESTART));
 
         assertTrue(sut.isRetry());
     }
@@ -165,7 +165,7 @@ class AuthorizationFlowActionTests {
     @Test
     @DisplayName("It should convert to an instance of class Retry")
     public void shouldConvertToRetry() {
-        AuthorizationFlowAction sut = new Retry(List.of("restart"));
+        AuthorizationFlowAction sut = new Retry(List.of(RetryOption.RESTART));
 
         assertDoesNotThrow(sut::asRetry);
     }

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
@@ -193,7 +193,8 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should yield true if instance is of type AttemptFailedPaymentDetail")
     public void shouldYieldTrueIfAttemptFailedPaymentDetail() {
-        PaymentDetail sut = new AttemptFailedPaymentDetail(null,
+        PaymentDetail sut = new AttemptFailedPaymentDetail(
+                null,
                 ZonedDateTime.now(Clock.systemUTC()),
                 AttemptFailedPaymentDetail.FailureStage.AUTHORIZING,
                 "failed for some reason",
@@ -205,7 +206,8 @@ class PaymentDetailTests {
     @Test
     @DisplayName("It should convert to an instance of class AttemptFailedPaymentDetail")
     public void shouldConvertToAttemptFailedPaymentDetail() {
-        PaymentDetail sut = new AttemptFailedPaymentDetail(null,
+        PaymentDetail sut = new AttemptFailedPaymentDetail(
+                null,
                 ZonedDateTime.now(Clock.systemUTC()),
                 AttemptFailedPaymentDetail.FailureStage.AUTHORIZING,
                 "failed for some reason",

--- a/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentdetail/PaymentDetailTests.java
@@ -189,4 +189,38 @@ class PaymentDetailTests {
 
         assertEquals(String.format("Payment is of type %s.", sut.getClass().getSimpleName()), thrown.getMessage());
     }
+
+    @Test
+    @DisplayName("It should yield true if instance is of type AttemptFailedPaymentDetail")
+    public void shouldYieldTrueIfAttemptFailedPaymentDetail() {
+        PaymentDetail sut = new AttemptFailedPaymentDetail(null,
+                ZonedDateTime.now(Clock.systemUTC()),
+                AttemptFailedPaymentDetail.FailureStage.AUTHORIZING,
+                "failed for some reason",
+                null);
+
+        assertTrue(sut.isAttemptFailed());
+    }
+
+    @Test
+    @DisplayName("It should convert to an instance of class AttemptFailedPaymentDetail")
+    public void shouldConvertToAttemptFailedPaymentDetail() {
+        PaymentDetail sut = new AttemptFailedPaymentDetail(null,
+                ZonedDateTime.now(Clock.systemUTC()),
+                AttemptFailedPaymentDetail.FailureStage.AUTHORIZING,
+                "failed for some reason",
+                null);
+
+        assertDoesNotThrow(sut::asAttemptFailed);
+    }
+
+    @Test
+    @DisplayName("It should throw an error when converting to AttemptFailedPaymentDetail")
+    public void shouldNotConvertToAttemptFailedPaymentDetail() {
+        PaymentDetail sut = new AuthorizationRequiredPaymentDetail();
+
+        Throwable thrown = assertThrows(TrueLayerException.class, sut::asAttemptFailed);
+
+        assertEquals(String.format("Payment is of type %s.", sut.getClass().getSimpleName()), thrown.getMessage());
+    }
 }

--- a/src/test/java/com/truelayer/java/payments/entities/paymentmethod/PaymentMethodTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentmethod/PaymentMethodTests.java
@@ -12,7 +12,7 @@ class PaymentMethodTests {
     @Test
     @DisplayName("It should yield true if instance is of type BankTransfer")
     public void shouldYieldTrueIfBankTransfer() {
-        PaymentMethod sut = new BankTransfer(null, null);
+        PaymentMethod sut = new BankTransfer(null, null, null);
 
         assertTrue(sut.isBankTransfer());
     }
@@ -20,7 +20,7 @@ class PaymentMethodTests {
     @Test
     @DisplayName("It should convert to an instance of class BankTransfer")
     public void shouldConvertToBankTransfer() {
-        PaymentMethod sut = new BankTransfer(null, null);
+        PaymentMethod sut = new BankTransfer(null, null, null);
 
         assertDoesNotThrow(sut::asBankTransfer);
     }
@@ -58,7 +58,7 @@ class PaymentMethodTests {
     @Test
     @DisplayName("It should throw an error when converting to Mandate")
     public void shouldNotConvertToMandate() {
-        PaymentMethod sut = new BankTransfer(null, null);
+        PaymentMethod sut = new BankTransfer(null, null, null);
 
         Throwable thrown = assertThrows(TrueLayerException.class, sut::asMandate);
 

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.attempt_failed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.attempt_failed.json
@@ -1,0 +1,56 @@
+{
+  "id": "24c8aae5-fbe9-4b5e-87d0-***",
+  "amount_in_minor": 475,
+  "currency": "GBP",
+  "user": {
+    "id": "90a4e9d7-8b0a-4498-87a3-***"
+  },
+  "payment_method": {
+    "type": "bank_transfer",
+    "beneficiary": {
+      "type": "merchant_account",
+      "reference": "5c3d16d6-1439-4b64-a084-***",
+      "merchant_account_id": "93e2c5f1-d935-47aa-90c0-***"
+    },
+    "provider_selection": {
+      "type": "preselected",
+      "provider_id": "mock-payments-gb-redirect",
+      "scheme_id": "faster_payments_service",
+      "remitter": {
+        "account_holder_name": "John Doe",
+        "account_identifier": {
+          "type": "sort_code_account_number",
+          "sort_code": "123456",
+          "account_number": "12345678"
+        }
+      }
+    },
+    "retry": {}
+  },
+  "created_at": "2024-07-19T15:19:01.691821Z",
+  "status": "attempt_failed",
+  "authorization_flow": {
+    "actions": {
+      "next": {
+        "type": "retry",
+        "retry_options": [
+          "restart"
+        ]
+      }
+    },
+    "configuration": {
+      "provider_selection": {},
+      "redirect": {
+        "return_uri": "http://localhost:3000/callback",
+        "direct_return_uri": "http://localhost:3000/callback"
+      },
+      "retry": {}
+    }
+  },
+  "failed_at": "2024-07-19T15:19:03.207135Z",
+  "failure_stage": "authorizing",
+  "failure_reason": "authorization_failed",
+  "metadata": {
+    "a_custom_key": "a-custom-value"
+  }
+}


### PR DESCRIPTION
# Description

Add support for `retry` parameter:
- customers can opt in to retry feature initialising the `retry` property in the `CreatePayment.PaymentMethod.BankTransfer` object
- added support for new `AttemptFailed` payment details 
- added unit, integration and acceptance tests

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation