### PR TITLE
[ACL-174] Improve retry payments acceptance tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
 
     // Mocking libraries
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.12.0'
-    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.9.0'
+    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.9.1'
 
     // Wait test utility
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=13.1.0
+version=13.1.1
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/


### PR DESCRIPTION
# Description

When testing `attempt_failed` payment details scenario, poll payment status to avoid issues when there's a delay in consuming status update events

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation