### PR TITLE
[ACL-175] Fix missing EqualsAndHashCode Lombok annotations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=13.1.1
+version=13.1.2
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/entities/accountidentifier/BbanAccountIdentifier.java
+++ b/src/main/java/com/truelayer/java/entities/accountidentifier/BbanAccountIdentifier.java
@@ -3,10 +3,12 @@ package com.truelayer.java.entities.accountidentifier;
 import static com.truelayer.java.entities.accountidentifier.AccountIdentifier.Type.BBAN;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class BbanAccountIdentifier extends AccountIdentifier {
     private final Type type = BBAN;
 

--- a/src/main/java/com/truelayer/java/entities/accountidentifier/IbanAccountIdentifier.java
+++ b/src/main/java/com/truelayer/java/entities/accountidentifier/IbanAccountIdentifier.java
@@ -1,10 +1,12 @@
 package com.truelayer.java.entities.accountidentifier;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class IbanAccountIdentifier extends AccountIdentifier {
     private final Type type = Type.IBAN;
 

--- a/src/main/java/com/truelayer/java/entities/accountidentifier/NrbAccountIdentifier.java
+++ b/src/main/java/com/truelayer/java/entities/accountidentifier/NrbAccountIdentifier.java
@@ -3,10 +3,12 @@ package com.truelayer.java.entities.accountidentifier;
 import static com.truelayer.java.entities.accountidentifier.AccountIdentifier.Type.NRB;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class NrbAccountIdentifier extends AccountIdentifier {
     private final Type type = NRB;
 

--- a/src/main/java/com/truelayer/java/entities/accountidentifier/SortCodeAccountNumberAccountIdentifier.java
+++ b/src/main/java/com/truelayer/java/entities/accountidentifier/SortCodeAccountNumberAccountIdentifier.java
@@ -1,10 +1,12 @@
 package com.truelayer.java.entities.accountidentifier;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class SortCodeAccountNumberAccountIdentifier extends AccountIdentifier {
     private final Type type = Type.SORT_CODE_ACCOUNT_NUMBER;
 

--- a/src/main/java/com/truelayer/java/mandates/entities/beneficiary/ExternalAccount.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/beneficiary/ExternalAccount.java
@@ -4,10 +4,12 @@ import static com.truelayer.java.mandates.entities.beneficiary.Beneficiary.Type.
 
 import com.truelayer.java.entities.accountidentifier.AccountIdentifier;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class ExternalAccount extends Beneficiary {
     private final Type type = EXTERNAL_ACCOUNT;
 

--- a/src/main/java/com/truelayer/java/mandates/entities/beneficiary/MerchantAccount.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/beneficiary/MerchantAccount.java
@@ -1,10 +1,12 @@
 package com.truelayer.java.mandates.entities.beneficiary;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class MerchantAccount extends Beneficiary {
     private final Type type = Type.MERCHANT_ACCOUNT;
 

--- a/src/main/java/com/truelayer/java/mandates/entities/mandate/VRPCommercialMandate.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/mandate/VRPCommercialMandate.java
@@ -5,10 +5,12 @@ import static com.truelayer.java.mandates.entities.mandate.Mandate.Type.COMMERCI
 import com.truelayer.java.mandates.entities.beneficiary.Beneficiary;
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class VRPCommercialMandate extends Mandate {
 
     private final Type type = COMMERCIAL;

--- a/src/main/java/com/truelayer/java/mandates/entities/mandate/VRPSweepingMandate.java
+++ b/src/main/java/com/truelayer/java/mandates/entities/mandate/VRPSweepingMandate.java
@@ -5,10 +5,12 @@ import static com.truelayer.java.mandates.entities.mandate.Mandate.Type.SWEEPING
 import com.truelayer.java.mandates.entities.beneficiary.Beneficiary;
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class VRPSweepingMandate extends Mandate {
 
     private final Type type = SWEEPING;

--- a/src/main/java/com/truelayer/java/payments/entities/beneficiary/ExternalAccount.java
+++ b/src/main/java/com/truelayer/java/payments/entities/beneficiary/ExternalAccount.java
@@ -4,10 +4,12 @@ import static com.truelayer.java.payments.entities.beneficiary.Beneficiary.Type.
 
 import com.truelayer.java.entities.accountidentifier.AccountIdentifier;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class ExternalAccount extends Beneficiary {
     private final Type type = EXTERNAL_ACCOUNT;
 

--- a/src/main/java/com/truelayer/java/payments/entities/beneficiary/MerchantAccount.java
+++ b/src/main/java/com/truelayer/java/payments/entities/beneficiary/MerchantAccount.java
@@ -1,10 +1,12 @@
 package com.truelayer.java.payments.entities.beneficiary;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class MerchantAccount extends Beneficiary {
     private final Type type = Type.MERCHANT_ACCOUNT;
 

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/BankTransfer.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/BankTransfer.java
@@ -8,10 +8,12 @@ import com.truelayer.java.payments.entities.beneficiary.Beneficiary;
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import java.util.Optional;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class BankTransfer extends PaymentMethod {
     private final Type type = BANK_TRANSFER;
 

--- a/src/main/java/com/truelayer/java/payments/entities/paymentmethod/Mandate.java
+++ b/src/main/java/com/truelayer/java/payments/entities/paymentmethod/Mandate.java
@@ -6,10 +6,12 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.truelayer.java.payments.entities.retry.Retry;
 import java.util.Optional;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class Mandate extends PaymentMethod {
     private final Type type = MANDATE;
 

--- a/src/main/java/com/truelayer/java/payments/entities/providerselection/PreselectedProviderSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/providerselection/PreselectedProviderSelection.java
@@ -3,10 +3,12 @@ package com.truelayer.java.payments.entities.providerselection;
 import com.truelayer.java.entities.Remitter;
 import com.truelayer.java.payments.entities.SchemeId;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @Builder
+@EqualsAndHashCode(callSuper = false)
 public class PreselectedProviderSelection extends ProviderSelection {
     private final Type type = Type.PRESELECTED;
 

--- a/src/main/java/com/truelayer/java/payments/entities/providerselection/UserSelectedProviderSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/providerselection/UserSelectedProviderSelection.java
@@ -4,10 +4,12 @@ import com.truelayer.java.entities.ProviderFilter;
 import com.truelayer.java.payments.entities.SchemeId;
 import com.truelayer.java.payments.entities.schemeselection.SchemeSelection;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Builder
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class UserSelectedProviderSelection extends ProviderSelection {
     private final Type type = Type.USER_SELECTED;
 

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
@@ -3,7 +3,6 @@ package com.truelayer.java.payments.entities.schemeselection;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.experimental.Accessors;
 
 @Getter
 @Builder

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
@@ -11,6 +11,5 @@ import lombok.experimental.Accessors;
 public class InstantOnlySchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_ONLY;
 
-    @Accessors(fluent = true)
     private boolean allowRemitterFee;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
@@ -1,15 +1,20 @@
 package com.truelayer.java.payments.entities.schemeselection;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 
 @Getter
 @Builder
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class InstantOnlySchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_ONLY;
 
-    // @Accessors(fluent = true)
+    @Accessors(fluent = true)
+    @JsonProperty // Jackson's @JsonProperty is required for serialization to work as expected
     private boolean allowRemitterFee;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
@@ -10,5 +10,6 @@ import lombok.Getter;
 public class InstantOnlySchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_ONLY;
 
+    // @Accessors(fluent = true)
     private boolean allowRemitterFee;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantOnlySchemeSelection.java
@@ -1,11 +1,13 @@
 package com.truelayer.java.payments.entities.schemeselection;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
 @Getter
 @Builder
+@EqualsAndHashCode(callSuper = false)
 public class InstantOnlySchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_ONLY;
 

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
@@ -3,7 +3,6 @@ package com.truelayer.java.payments.entities.schemeselection;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.experimental.Accessors;
 
 @Getter
 @Builder

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
@@ -1,11 +1,13 @@
 package com.truelayer.java.payments.entities.schemeselection;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
 @Getter
 @Builder
+@EqualsAndHashCode(callSuper = false)
 public class InstantPreferredSchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_PREFERRED;
 

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
@@ -10,5 +10,9 @@ import lombok.Getter;
 public class InstantPreferredSchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_PREFERRED;
 
+    // Apparently there's a problem with fluent setters and serialization...
+    // https://stackoverflow.com/questions/72570822/accessorsfluent-true-does-not-work-with-jakson
+
+    // @Accessors(fluent = true)
     private boolean allowRemitterFee;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
@@ -11,6 +11,5 @@ import lombok.experimental.Accessors;
 public class InstantPreferredSchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_PREFERRED;
 
-    @Accessors(fluent = true)
     private boolean allowRemitterFee;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/InstantPreferredSchemeSelection.java
@@ -1,18 +1,20 @@
 package com.truelayer.java.payments.entities.schemeselection;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 
 @Getter
 @Builder
 @EqualsAndHashCode(callSuper = false)
+@ToString
 public class InstantPreferredSchemeSelection extends SchemeSelection {
     private final Type type = Type.INSTANT_PREFERRED;
 
-    // Apparently there's a problem with fluent setters and serialization...
-    // https://stackoverflow.com/questions/72570822/accessorsfluent-true-does-not-work-with-jakson
-
-    // @Accessors(fluent = true)
+    @Accessors(fluent = true)
+    @JsonProperty // Jackson's @JsonProperty is required for serialization to work as expected
     private boolean allowRemitterFee;
 }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/SchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/SchemeSelection.java
@@ -18,6 +18,9 @@ public abstract class SchemeSelection {
     @JsonIgnore
     public abstract Type getType();
 
+    // @JsonIgnore
+    // public abstract boolean allowRemitterFee();
+
     public static InstantOnlySchemeSelection.InstantOnlySchemeSelectionBuilder instantOnly() {
         return InstantOnlySchemeSelection.builder();
     }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/SchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/SchemeSelection.java
@@ -18,9 +18,6 @@ public abstract class SchemeSelection {
     @JsonIgnore
     public abstract Type getType();
 
-    @JsonIgnore
-    public abstract boolean allowRemitterFee();
-
     public static InstantOnlySchemeSelection.InstantOnlySchemeSelectionBuilder instantOnly() {
         return InstantOnlySchemeSelection.builder();
     }

--- a/src/main/java/com/truelayer/java/payments/entities/schemeselection/SchemeSelection.java
+++ b/src/main/java/com/truelayer/java/payments/entities/schemeselection/SchemeSelection.java
@@ -18,8 +18,8 @@ public abstract class SchemeSelection {
     @JsonIgnore
     public abstract Type getType();
 
-    // @JsonIgnore
-    // public abstract boolean allowRemitterFee();
+    @JsonIgnore
+    public abstract boolean allowRemitterFee();
 
     public static InstantOnlySchemeSelection.InstantOnlySchemeSelectionBuilder instantOnly() {
         return InstantOnlySchemeSelection.builder();

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsProvidersAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsProvidersAcceptanceTests.java
@@ -16,9 +16,9 @@ public class PaymentsProvidersAcceptanceTests extends AcceptanceTests {
     public static final String PROVIDER_ID = "mock-payments-gb-redirect";
 
     @Test
-    @DisplayName("It should get by id a payments provider")
+    @DisplayName("It should get a payments provider by id")
     @SneakyThrows
-    public void shouldCreateAPaymentWithUserSelectionProvider() {
+    public void shouldGetAPaymentsProviderById() {
         ApiResponse<PaymentsProvider> getPaymentsProviderResponse =
                 tlClient.paymentsProviders().getProvider(PROVIDER_ID).get();
 

--- a/src/test/java/com/truelayer/java/payments/entities/SchemeSelectionTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/SchemeSelectionTests.java
@@ -1,0 +1,46 @@
+package com.truelayer.java.payments.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.truelayer.java.payments.entities.schemeselection.SchemeSelection;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SchemeSelectionTests {
+
+    @DisplayName("Scheme selection base class should yield the expected type and allow_remitter_fee")
+    @ParameterizedTest(name = "object={0}, expected type={1}, expected allow_remitter_fee={2}")
+    @MethodSource("provideSchemeSelectionTestParameters")
+    public void baseClassShouldYieldExpectedDetails(
+            SchemeSelection schemeSelection, SchemeSelection.Type expectedType, boolean expectAllowRemitterFee) {
+        assertEquals(schemeSelection.getType(), expectedType);
+        assertEquals(schemeSelection.allowRemitterFee(), expectAllowRemitterFee);
+    }
+
+    private static Stream<Arguments> provideSchemeSelectionTestParameters() {
+        return Stream.of(
+                Arguments.of(
+                        SchemeSelection.instantOnly().allowRemitterFee(true).build(),
+                        SchemeSelection.Type.INSTANT_ONLY,
+                        true),
+                Arguments.of(
+                        SchemeSelection.instantOnly().allowRemitterFee(false).build(),
+                        SchemeSelection.Type.INSTANT_ONLY,
+                        false),
+                Arguments.of(
+                        SchemeSelection.instantPreferred()
+                                .allowRemitterFee(true)
+                                .build(),
+                        SchemeSelection.Type.INSTANT_PREFERRED,
+                        true),
+                Arguments.of(
+                        SchemeSelection.instantPreferred()
+                                .allowRemitterFee(false)
+                                .build(),
+                        SchemeSelection.Type.INSTANT_PREFERRED,
+                        false));
+    }
+}

--- a/src/test/java/com/truelayer/java/payments/entities/paymentmethod/PaymentMethodTests.java
+++ b/src/test/java/com/truelayer/java/payments/entities/paymentmethod/PaymentMethodTests.java
@@ -3,6 +3,9 @@ package com.truelayer.java.payments.entities.paymentmethod;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.truelayer.java.TrueLayerException;
+import com.truelayer.java.entities.Remitter;
+import com.truelayer.java.payments.entities.beneficiary.Beneficiary;
+import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,5 +67,52 @@ class PaymentMethodTests {
 
         assertEquals(
                 String.format("Payment method is of type %s.", sut.getClass().getSimpleName()), thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("BankTransfer class should implement equals method")
+    public void bankTransferShouldImplementEqualsMethod() {
+        String aBeneficiaryReference = "a_beneficiary_reference";
+        String anotherBeneficiaryReference = "another_beneficiary_reference";
+        String aRemitterName = "a_remitter_name";
+        String anotherRemitterName = "another_remitter_name";
+
+        BankTransfer bankTransfer = createBankTransfer(aBeneficiaryReference, aRemitterName);
+        BankTransfer identicalBankTransfer = createBankTransfer(aBeneficiaryReference, aRemitterName);
+        BankTransfer differentBankTransfer = createBankTransfer(anotherBeneficiaryReference, anotherRemitterName);
+
+        assertEquals(bankTransfer, identicalBankTransfer);
+        assertNotEquals(bankTransfer, differentBankTransfer);
+    }
+
+    @Test
+    @DisplayName("Mandate class should implement equals method")
+    public void mandateShouldImplementEqualsMethod() {
+        String aMandateId = UUID.randomUUID().toString();
+        String anotherMandateId = UUID.randomUUID().toString();
+
+        Mandate mandate = createMandate(aMandateId);
+        Mandate identicalMandate = createMandate(aMandateId);
+        Mandate differentMandate = createMandate(anotherMandateId);
+
+        assertEquals(mandate, identicalMandate);
+        assertNotEquals(mandate, differentMandate);
+    }
+
+    private static BankTransfer createBankTransfer(String beneficiaryReference, String remitterName) {
+        return BankTransfer.builder()
+                .providerSelection(ProviderSelection.preselected()
+                        .remitter(Remitter.builder()
+                                .accountHolderName(remitterName)
+                                .build())
+                        .build())
+                .beneficiary(Beneficiary.externalAccount()
+                        .reference(beneficiaryReference)
+                        .build())
+                .build();
+    }
+
+    private static Mandate createMandate(String id) {
+        return Mandate.builder().mandateId(id).build();
     }
 }


### PR DESCRIPTION
# Description

- Add missing `EqualsAndHashCode` lombok annotations on `PaymentMethod` subclasses and related properties
- Add unit tests

## Type of change

Please select multiple options if required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation