### PR TITLE
Add search payments providers endpoint + statement reference to merchant account

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=16.1.0
+version=16.2.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/payments/entities/beneficiary/MerchantAccount.java
+++ b/src/main/java/com/truelayer/java/payments/entities/beneficiary/MerchantAccount.java
@@ -18,4 +18,6 @@ public class MerchantAccount extends Beneficiary {
     private String reference;
 
     private Verification verification;
+
+    private String statementReference;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/IPaymentsProvidersApi.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/IPaymentsProvidersApi.java
@@ -3,10 +3,10 @@ package com.truelayer.java.paymentsproviders;
 import com.truelayer.java.entities.RequestScopes;
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.paymentsproviders.entities.PaymentsProvider;
+import com.truelayer.java.paymentsproviders.entities.SearchPaymentProvidersRequest;
+import com.truelayer.java.paymentsproviders.entities.SearchPaymentProvidersResponse;
 import java.util.concurrent.CompletableFuture;
-import retrofit2.http.GET;
-import retrofit2.http.Path;
-import retrofit2.http.Tag;
+import retrofit2.http.*;
 
 /**
  * Interface that models /payments-providers/* endpoints
@@ -16,4 +16,8 @@ public interface IPaymentsProvidersApi {
     @GET("/payments-providers/{id}")
     CompletableFuture<ApiResponse<PaymentsProvider>> getProvider(
             @Tag RequestScopes scopes, @Path("id") String providerId);
+
+    @POST("/payments-providers/search")
+    CompletableFuture<ApiResponse<SearchPaymentProvidersResponse>> searchPaymentProviders(
+            @Tag RequestScopes scopes, @Body SearchPaymentProvidersRequest request);
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/IPaymentsProvidersHandler.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/IPaymentsProvidersHandler.java
@@ -2,6 +2,8 @@ package com.truelayer.java.paymentsproviders;
 
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.paymentsproviders.entities.PaymentsProvider;
+import com.truelayer.java.paymentsproviders.entities.SearchPaymentProvidersRequest;
+import com.truelayer.java.paymentsproviders.entities.SearchPaymentProvidersResponse;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -19,4 +21,14 @@ public interface IPaymentsProvidersHandler {
      * @see <a href="https://docs.truelayer.com/reference/get-payment-provider"><i>Get Payment Provider</i> API reference</a>
      */
     CompletableFuture<ApiResponse<PaymentsProvider>> getProvider(String providerId);
+
+    /**
+     * Returns a list of payments providers.
+     *
+     * @param request the request with filters to search providers
+     * @return the response of the <i>Search Payments Providers</i> operation
+     * @see <a href="https://docs.truelayer.com/reference/search-payment-providers"><i>Search Payment Providers</i> API reference</a>
+     */
+    CompletableFuture<ApiResponse<SearchPaymentProvidersResponse>> searchProviders(
+            SearchPaymentProvidersRequest request);
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/PaymentsProvidersHandler.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/PaymentsProvidersHandler.java
@@ -6,6 +6,8 @@ import com.truelayer.java.IAuthenticatedHandler;
 import com.truelayer.java.entities.RequestScopes;
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.paymentsproviders.entities.PaymentsProvider;
+import com.truelayer.java.paymentsproviders.entities.SearchPaymentProvidersRequest;
+import com.truelayer.java.paymentsproviders.entities.SearchPaymentProvidersResponse;
 import java.util.concurrent.CompletableFuture;
 import lombok.Builder;
 
@@ -28,5 +30,11 @@ public class PaymentsProvidersHandler implements IAuthenticatedHandler, IPayment
     @Override
     public CompletableFuture<ApiResponse<PaymentsProvider>> getProvider(String providerId) {
         return paymentsProvidersApi.getProvider(getRequestScopes(), providerId);
+    }
+
+    @Override
+    public CompletableFuture<ApiResponse<SearchPaymentProvidersResponse>> searchProviders(
+            SearchPaymentProvidersRequest request) {
+        return paymentsProvidersApi.searchPaymentProviders(getRequestScopes(), request);
     }
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/AisConsent.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/AisConsent.java
@@ -1,11 +1,12 @@
 package com.truelayer.java.paymentsproviders.entities;
 
+import java.util.List;
 import lombok.*;
 
 @Builder
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class AisConsent {
+    private List<Scope> scopes;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/AuthorizationFlow.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/AuthorizationFlow.java
@@ -6,6 +6,6 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class AuthorizationFlow {
+    private Configuration configuration;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/BankTransferCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/BankTransferCapabilities.java
@@ -3,9 +3,12 @@ package com.truelayer.java.paymentsproviders.entities;
 import com.truelayer.java.entities.ProviderAvailability;
 import com.truelayer.java.payments.entities.ReleaseChannel;
 import java.util.List;
-import lombok.Value;
+import lombok.*;
 
-@Value
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
 public class BankTransferCapabilities {
     ReleaseChannel releaseChannel;
 

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Capabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Capabilities.java
@@ -1,8 +1,11 @@
 package com.truelayer.java.paymentsproviders.entities;
 
-import lombok.Value;
+import lombok.*;
 
-@Value
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
 public class Capabilities {
     PaymentsCapabilities payments;
 

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Configuration.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Configuration.java
@@ -1,0 +1,17 @@
+package com.truelayer.java.paymentsproviders.entities;
+
+import lombok.*;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class Configuration {
+    private ProviderSelection providerSelection;
+
+    private Redirect redirect;
+
+    private Form form;
+
+    private Consent consent;
+}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Consent.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Consent.java
@@ -6,6 +6,6 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class Consent {
+    private Requirements requirements;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Form.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Form.java
@@ -1,11 +1,12 @@
 package com.truelayer.java.paymentsproviders.entities;
 
+import java.util.List;
 import lombok.*;
 
 @Builder
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class Form {
+    private List<InputType> inputTypes;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Icon.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Icon.java
@@ -6,6 +6,6 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class Icon {
+    private IconType type;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/IconType.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/IconType.java
@@ -1,0 +1,18 @@
+package com.truelayer.java.paymentsproviders.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum IconType {
+    DEFAULT("default"),
+    EXTENDED("extended"),
+    EXTENDED_SMALL("extended_small"),
+    EXTENDED_MEDIUM("extended_medium"),
+    EXTENDED_LARGE("extended_large");
+
+    @JsonValue
+    private final String iconType;
+}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/InputType.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/InputType.java
@@ -1,0 +1,16 @@
+package com.truelayer.java.paymentsproviders.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum InputType {
+    TEXT("text"),
+    TEXT_WITH_IMAGE("text_with_image"),
+    SELECT("select");
+
+    @JsonValue
+    private final String inputType;
+}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/MandatesCapabilities.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/MandatesCapabilities.java
@@ -1,8 +1,11 @@
 package com.truelayer.java.paymentsproviders.entities;
 
-import lombok.Value;
+import lombok.*;
 
-@Value
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
 public class MandatesCapabilities {
     VrpSweepingCapabilities vrpSweeping;
 

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/PisConsent.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/PisConsent.java
@@ -6,6 +6,4 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
-}
+public class PisConsent {}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/ProviderSelection.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/ProviderSelection.java
@@ -6,6 +6,6 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class ProviderSelection {
+    private Icon icon;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Redirect.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Redirect.java
@@ -6,6 +6,4 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
-}
+public class Redirect {}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Requirements.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Requirements.java
@@ -6,6 +6,8 @@ import lombok.*;
 @Getter
 @ToString
 @EqualsAndHashCode
-public class PaymentsCapabilities {
-    BankTransferCapabilities bankTransfer;
+public class Requirements {
+    private PisConsent pis;
+
+    private AisConsent ais;
 }

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/Scope.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/Scope.java
@@ -1,0 +1,15 @@
+package com.truelayer.java.paymentsproviders.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Scope {
+    ACCOUNTS("accounts"),
+    BALANCE("balance");
+
+    @JsonValue
+    private final String scope;
+}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/SearchPaymentProvidersRequest.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/SearchPaymentProvidersRequest.java
@@ -1,0 +1,29 @@
+package com.truelayer.java.paymentsproviders.entities;
+
+import com.truelayer.java.entities.CurrencyCode;
+import com.truelayer.java.payments.entities.CountryCode;
+import com.truelayer.java.payments.entities.CustomerSegment;
+import com.truelayer.java.payments.entities.ReleaseChannel;
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class SearchPaymentProvidersRequest {
+    private List<CountryCode> countries;
+
+    private List<CurrencyCode> currencies;
+
+    private ReleaseChannel releaseChannel;
+
+    private List<CustomerSegment> customerSegments;
+
+    private Capabilities capabilities;
+
+    private AuthorizationFlow authorizationFlow;
+}

--- a/src/main/java/com/truelayer/java/paymentsproviders/entities/SearchPaymentProvidersResponse.java
+++ b/src/main/java/com/truelayer/java/paymentsproviders/entities/SearchPaymentProvidersResponse.java
@@ -1,0 +1,9 @@
+package com.truelayer.java.paymentsproviders.entities;
+
+import java.util.List;
+import lombok.Value;
+
+@Value
+public class SearchPaymentProvidersResponse {
+    List<PaymentsProvider> items;
+}

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsAcceptanceTests.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 import lombok.*;
 import okhttp3.*;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -663,6 +664,7 @@ public class PaymentsAcceptanceTests extends AcceptanceTests {
                 return Beneficiary.merchantAccount()
                         .merchantAccountId(account.getId())
                         .reference(UUID.randomUUID().toString())
+                        .statementReference(RandomStringUtils.randomAlphanumeric(18))
                         .build();
             case PLN:
                 return Beneficiary.externalAccount()

--- a/src/test/java/com/truelayer/java/acceptance/PaymentsProvidersAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/PaymentsProvidersAcceptanceTests.java
@@ -3,8 +3,13 @@ package com.truelayer.java.acceptance;
 import static com.truelayer.java.TestUtils.assertNotError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.http.entities.ApiResponse;
-import com.truelayer.java.paymentsproviders.entities.PaymentsProvider;
+import com.truelayer.java.payments.entities.CountryCode;
+import com.truelayer.java.payments.entities.CustomerSegment;
+import com.truelayer.java.payments.entities.ReleaseChannel;
+import com.truelayer.java.paymentsproviders.entities.*;
+import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -24,5 +29,32 @@ public class PaymentsProvidersAcceptanceTests extends AcceptanceTests {
 
         assertNotError(getPaymentsProviderResponse);
         assertEquals(getPaymentsProviderResponse.getData().getId(), PROVIDER_ID);
+    }
+
+    @Test
+    @DisplayName("It should search for payments providers")
+    @SneakyThrows
+    public void shouldSearchPaymentsProviders() {
+        SearchPaymentProvidersRequest request = SearchPaymentProvidersRequest.builder()
+                .countries(List.of(CountryCode.GB))
+                .currencies(List.of(CurrencyCode.GBP))
+                .releaseChannel(ReleaseChannel.PRIVATE_BETA)
+                .capabilities(Capabilities.builder()
+                        .payments(PaymentsCapabilities.builder()
+                                .bankTransfer(BankTransferCapabilities.builder().build())
+                                .build())
+                        .build())
+                .customerSegments(List.of(CustomerSegment.RETAIL))
+                .authorizationFlow(AuthorizationFlow.builder()
+                        .configuration(Configuration.builder()
+                                .redirect(Redirect.builder().build())
+                                .build())
+                        .build())
+                .build();
+
+        ApiResponse<SearchPaymentProvidersResponse> searchPaymentsProvidersResponse =
+                tlClient.paymentsProviders().searchProviders(request).get();
+
+        assertNotError(searchPaymentsProvidersResponse);
     }
 }

--- a/src/test/java/com/truelayer/java/integration/PaymentsProvidersIntegrationTests.java
+++ b/src/test/java/com/truelayer/java/integration/PaymentsProvidersIntegrationTests.java
@@ -7,9 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.truelayer.java.TestUtils;
 import com.truelayer.java.TestUtils.RequestStub;
+import com.truelayer.java.entities.CurrencyCode;
 import com.truelayer.java.http.entities.ApiResponse;
-import com.truelayer.java.paymentsproviders.entities.PaymentsProvider;
+import com.truelayer.java.payments.entities.CountryCode;
+import com.truelayer.java.payments.entities.CustomerSegment;
+import com.truelayer.java.payments.entities.ReleaseChannel;
+import com.truelayer.java.paymentsproviders.entities.*;
 import java.util.Collections;
+import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +48,53 @@ public class PaymentsProvidersIntegrationTests extends IntegrationTests {
         verifyGeneratedToken(Collections.singletonList(PAYMENTS));
         assertNotError(response);
         PaymentsProvider expected = TestUtils.deserializeJsonFileTo(jsonResponseFile, PaymentsProvider.class);
+        assertEquals(expected, response.getData());
+    }
+
+    @Test
+    @DisplayName("It should return a list of payments provider after search")
+    @SneakyThrows
+    public void shouldReturnAListOfPaymentsProvidersOnSearchPaymentsProviders() {
+        String jsonResponseFile = "payments_providers/200.search_payments_providers.json";
+        RequestStub.New()
+                .method("post")
+                .path(urlPathEqualTo("/connect/token"))
+                .status(200)
+                .bodyFile("auth/200.access_token.json")
+                .build();
+        RequestStub.New()
+                .method("post")
+                .path(urlEqualTo("/payments-providers/search"))
+                .withAuthorization()
+                .status(200)
+                .bodyFile(jsonResponseFile)
+                .build();
+
+        SearchPaymentProvidersRequest searchPaymentProvidersRequest = SearchPaymentProvidersRequest.builder()
+                .countries(List.of(CountryCode.GB))
+                .currencies(List.of(CurrencyCode.GBP))
+                .releaseChannel(ReleaseChannel.PRIVATE_BETA)
+                .capabilities(Capabilities.builder()
+                        .payments(PaymentsCapabilities.builder()
+                                .bankTransfer(BankTransferCapabilities.builder().build())
+                                .build())
+                        .build())
+                .customerSegments(List.of(CustomerSegment.RETAIL))
+                .authorizationFlow(AuthorizationFlow.builder()
+                        .configuration(Configuration.builder()
+                                .redirect(Redirect.builder().build())
+                                .build())
+                        .build())
+                .build();
+
+        ApiResponse<SearchPaymentProvidersResponse> response = tlClient.paymentsProviders()
+                .searchProviders(searchPaymentProvidersRequest)
+                .get();
+
+        verifyGeneratedToken(Collections.singletonList(PAYMENTS));
+        assertNotError(response);
+        SearchPaymentProvidersResponse expected =
+                TestUtils.deserializeJsonFileTo(jsonResponseFile, SearchPaymentProvidersResponse.class);
         assertEquals(expected, response.getData());
     }
 }

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.attempt_failed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.attempt_failed.json
@@ -10,7 +10,8 @@
     "beneficiary": {
       "type": "merchant_account",
       "reference": "5c3d16d6-1439-4b64-a084-***",
-      "merchant_account_id": "93e2c5f1-d935-47aa-90c0-***"
+      "merchant_account_id": "93e2c5f1-d935-47aa-90c0-***",
+      "statement_reference": "a-statement-ref"
     },
     "provider_selection": {
       "type": "preselected",

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorization_required.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorization_required.json
@@ -12,7 +12,8 @@
       "type":"merchant_account",
       "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
       "account_holder_name": "john smith",
-      "reference": "a-reference"
+      "reference": "a-reference",
+      "statement_reference": "a-statement-ref"
     }
   },
   "created_at":"2022-01-17T17:13:18.214924Z",

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorized.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorized.json
@@ -38,6 +38,7 @@
       "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
       "account_holder_name":"john smith",
       "reference": "a-reference",
+      "statement_reference": "a-statement-ref",
       "verification": {
         "type": "automated",
         "remitter_date_of_birth": true,

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorizing.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.authorizing.json
@@ -35,7 +35,8 @@
       "type":"merchant_account",
       "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
       "account_holder_name":"john smith",
-      "reference": "a-reference"
+      "reference": "a-reference",
+      "statement_reference": "a-statement-ref"
     }
   },
   "created_at":"2022-01-17T17:13:18.214924Z",

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.executed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.executed.json
@@ -33,7 +33,8 @@
       "type":"merchant_account",
       "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
       "account_holder_name":"john smith",
-      "reference": "a-reference"
+      "reference": "a-reference",
+      "statement_reference": "a-statement-ref"
     }
   },
   "created_at":"2022-01-17T17:13:18.214924Z",

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.failed.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.failed.json
@@ -31,7 +31,8 @@
       "type":"merchant_account",
       "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
       "account_holder_name":"john smith",
-      "reference": "a-reference"
+      "reference": "a-reference",
+      "statement_reference": "a-statement-ref"
     }
   },
   "created_at":"2022-01-17T17:13:18.214924Z",

--- a/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.settled.json
+++ b/src/test/resources/__files/payments/200.get_payment_by_id.bank_transfer.settled.json
@@ -33,7 +33,8 @@
       "type":"merchant_account",
       "merchant_account_id":"e83c4c20-b2ad-4b73-8a32-***",
       "account_holder_name":"john smith",
-      "reference": "a-reference"
+      "reference": "a-reference",
+      "statement_reference": "a-statement-ref"
     }
   },
   "created_at":"2022-01-17T17:13:18.214924Z",

--- a/src/test/resources/__files/payments_providers/200.search_payments_providers.json
+++ b/src/test/resources/__files/payments_providers/200.search_payments_providers.json
@@ -1,0 +1,84 @@
+{
+  "items": [
+    {
+      "id": "mock-payments-gb-redirect",
+      "display_name": "Mock UK Payments - Redirect Flow",
+      "icon_uri": "https://providers-assets.truelayer.com/mock-payments-gb-redirect/icon.svg",
+      "logo_uri": "https://providers-assets.truelayer.com/mock-payments-gb-redirect/logo.svg",
+      "bg_color": "#44689a",
+      "country_code": "GB",
+      "swift_code": "MOCKGB05XXX",
+      "capabilities": {
+        "payments": {
+          "bank_transfer": {
+            "release_channel": "general_availability",
+            "availability": {
+              "recommended_status": "healthy",
+              "updated_at": "2024-12-04T10:16:27.0263076Z"
+            },
+            "schemes": [
+              {
+                "id": "faster_payments_service",
+                "requirements": [
+                  {
+                    "currencies": [
+                      "GBP"
+                    ],
+                    "account_identifier_types": [
+                      "sort_code_account_number"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "mandates": {
+          "vrp_sweeping": {
+            "release_channel": "private_beta"
+          },
+          "vrp_commercial": {
+            "release_channel": "private_beta"
+          }
+        }
+      },
+      "bin_ranges": []
+    },
+    {
+      "id": "mock-payments-gb-redirect-unhealthy",
+      "display_name": "Mock UK Payments - Redirect Flow (Unhealthy)",
+      "icon_uri": "https://providers-assets.truelayer.com/mock-payments-gb-redirect-unhealthy/icon.svg",
+      "logo_uri": "https://providers-assets.truelayer.com/mock-payments-gb-redirect-unhealthy/logo.svg",
+      "bg_color": "#44689a",
+      "country_code": "GB",
+      "swift_code": "MOCKGB06XXX",
+      "capabilities": {
+        "payments": {
+          "bank_transfer": {
+            "release_channel": "general_availability",
+            "availability": {
+              "recommended_status": "unhealthy",
+              "updated_at": "2024-12-04T10:16:27.0263076Z"
+            },
+            "schemes": [
+              {
+                "id": "faster_payments_service",
+                "requirements": [
+                  {
+                    "currencies": [
+                      "GBP"
+                    ],
+                    "account_identifier_types": [
+                      "sort_code_account_number"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bin_ranges": []
+    }
+  ]
+}


### PR DESCRIPTION
# Description

- add `statementReference` to merchant account beneficiary ([ACL-223](https://truelayer.atlassian.net/browse/ACL-223))
- add search payments providers endpoint ([ACL-187](https://truelayer.atlassian.net/browse/ACL-187))

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the relevant documentation