### PR TITLE
feat(ACL-251): Adds method to generate SU+ Authentication URI for FI payments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Please select multiple options if required.
 
 # Checklist:
 
-- [ ] I have updated the [gradle.properties](./../gradle.properties) file with the new version
+- [ ] I have updated the `gradle.properties` file with the new version
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code where necessary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Please select multiple options if required.
 
 # Checklist:
 
-- [ ] I have update the [gradle.properties](./../gradle.properties) file with the new version
+- [ ] I have updated the [gradle.properties](./../gradle.properties) file with the new version
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code where necessary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ Please select multiple options if required.
 
 # Checklist:
 
+- [ ] I have update the [gradle.properties](./../gradle.properties) file with the new version
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code where necessary

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     implementation group: 'org.tinylog', name: 'tinylog-impl', version: tinyLogVersion
 
     // JUnit test framework.
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.3'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.4'
 
     // Mocking libraries
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.14.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=16.2.0
+version=16.3.0
 
 # Artifacts properties
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/

--- a/src/main/java/com/truelayer/java/signupplus/ISignupPlusApi.java
+++ b/src/main/java/com/truelayer/java/signupplus/ISignupPlusApi.java
@@ -2,11 +2,11 @@ package com.truelayer.java.signupplus;
 
 import com.truelayer.java.entities.RequestScopes;
 import com.truelayer.java.http.entities.ApiResponse;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriRequest;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriResponse;
 import com.truelayer.java.signupplus.entities.UserData;
 import java.util.concurrent.CompletableFuture;
-import retrofit2.http.GET;
-import retrofit2.http.Query;
-import retrofit2.http.Tag;
+import retrofit2.http.*;
 
 public interface ISignupPlusApi {
 
@@ -20,4 +20,8 @@ public interface ISignupPlusApi {
     @GET("/signup-plus/payments")
     CompletableFuture<ApiResponse<UserData>> getUserDataByPayment(
             @Tag RequestScopes scopes, @Query("payment_id") String paymentId);
+
+    @POST("/signup-plus/authuri")
+    CompletableFuture<ApiResponse<GenerateAuthUriResponse>> generateAuthUri(
+            @Tag RequestScopes scopes, @Body GenerateAuthUriRequest request);
 }

--- a/src/main/java/com/truelayer/java/signupplus/ISignupPlusHandler.java
+++ b/src/main/java/com/truelayer/java/signupplus/ISignupPlusHandler.java
@@ -1,10 +1,14 @@
 package com.truelayer.java.signupplus;
 
 import com.truelayer.java.http.entities.ApiResponse;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriRequest;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriResponse;
 import com.truelayer.java.signupplus.entities.UserData;
 import java.util.concurrent.CompletableFuture;
 
 public interface ISignupPlusHandler {
 
     CompletableFuture<ApiResponse<UserData>> getUserDataByPayment(String paymentId);
+
+    CompletableFuture<ApiResponse<GenerateAuthUriResponse>> generateAuthUri(GenerateAuthUriRequest request);
 }

--- a/src/main/java/com/truelayer/java/signupplus/SignupPlusHandler.java
+++ b/src/main/java/com/truelayer/java/signupplus/SignupPlusHandler.java
@@ -5,6 +5,8 @@ import static com.truelayer.java.Constants.Scopes.SIGNUP_PLUS;
 import com.truelayer.java.IAuthenticatedHandler;
 import com.truelayer.java.entities.RequestScopes;
 import com.truelayer.java.http.entities.ApiResponse;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriRequest;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriResponse;
 import com.truelayer.java.signupplus.entities.UserData;
 import java.util.concurrent.CompletableFuture;
 import lombok.Builder;
@@ -25,5 +27,10 @@ public class SignupPlusHandler implements IAuthenticatedHandler, ISignupPlusHand
     @Override
     public CompletableFuture<ApiResponse<UserData>> getUserDataByPayment(String paymentId) {
         return signupPlusApi.getUserDataByPayment(getRequestScopes(), paymentId);
+    }
+
+    @Override
+    public CompletableFuture<ApiResponse<GenerateAuthUriResponse>> generateAuthUri(GenerateAuthUriRequest request) {
+        return signupPlusApi.generateAuthUri(getRequestScopes(), request);
     }
 }

--- a/src/main/java/com/truelayer/java/signupplus/entities/GenerateAuthUriRequest.java
+++ b/src/main/java/com/truelayer/java/signupplus/entities/GenerateAuthUriRequest.java
@@ -1,0 +1,16 @@
+package com.truelayer.java.signupplus.entities;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+public class GenerateAuthUriRequest {
+    private String paymentId;
+
+    private String state;
+}

--- a/src/main/java/com/truelayer/java/signupplus/entities/GenerateAuthUriResponse.java
+++ b/src/main/java/com/truelayer/java/signupplus/entities/GenerateAuthUriResponse.java
@@ -1,0 +1,11 @@
+package com.truelayer.java.signupplus.entities;
+
+import java.net.URI;
+import lombok.ToString;
+import lombok.Value;
+
+@ToString
+@Value
+public class GenerateAuthUriResponse {
+    URI authUri;
+}

--- a/src/test/java/com/truelayer/java/acceptance/SignupPlusAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/SignupPlusAcceptanceTests.java
@@ -55,10 +55,8 @@ public class SignupPlusAcceptanceTests extends AcceptanceTests {
     public void itShouldAuthorizeAFinPaymentAndThenGenerateAnAuthUri() {
         // Create and authorize a payment
         String paymentId = createAndAuthorizePayment("mock-payments-fi-redirect", CurrencyCode.EUR, RETURN_URI);
-        // wait for its settlement
         waitForPaymentStatusUpdate(tlClient, paymentId, Status.EXECUTED);
 
-        // get the identity data associated with that
         ApiResponse<GenerateAuthUriResponse> generateAuthUriResponse = tlClient.signupPlus()
                 .generateAuthUri(
                         GenerateAuthUriRequest.builder().paymentId(paymentId).build())

--- a/src/test/java/com/truelayer/java/acceptance/SignupPlusAcceptanceTests.java
+++ b/src/test/java/com/truelayer/java/acceptance/SignupPlusAcceptanceTests.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.truelayer.java.TestUtils;
 import com.truelayer.java.entities.*;
+import com.truelayer.java.entities.accountidentifier.AccountIdentifier;
+import com.truelayer.java.entities.accountidentifier.IbanAccountIdentifier;
 import com.truelayer.java.entities.accountidentifier.SortCodeAccountNumberAccountIdentifier;
 import com.truelayer.java.http.entities.ApiResponse;
 import com.truelayer.java.merchantaccounts.entities.MerchantAccount;
@@ -14,6 +16,8 @@ import com.truelayer.java.payments.entities.paymentdetail.Status;
 import com.truelayer.java.payments.entities.paymentmethod.PaymentMethod;
 import com.truelayer.java.payments.entities.providerselection.ProviderSelection;
 import com.truelayer.java.payments.entities.schemeselection.preselected.SchemeSelection;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriRequest;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriResponse;
 import com.truelayer.java.signupplus.entities.UserData;
 import java.net.URI;
 import java.time.LocalDate;
@@ -45,9 +49,35 @@ public class SignupPlusAcceptanceTests extends AcceptanceTests {
         assertNotError(userDataResponse);
     }
 
+    @Test
+    @DisplayName("It should create a payment and generate an auth URI via Signup+ in FI")
+    @SneakyThrows
+    public void itShouldAuthorizeAFinPaymentAndThenGenerateAnAuthUri() {
+        // Create and authorize a payment
+        String paymentId = createAndAuthorizePayment("mock-payments-fi-redirect", CurrencyCode.EUR, RETURN_URI);
+        // wait for its settlement
+        waitForPaymentStatusUpdate(tlClient, paymentId, Status.EXECUTED);
+
+        // get the identity data associated with that
+        ApiResponse<GenerateAuthUriResponse> generateAuthUriResponse = tlClient.signupPlus()
+                .generateAuthUri(
+                        GenerateAuthUriRequest.builder().paymentId(paymentId).build())
+                .get();
+        assertNotError(generateAuthUriResponse);
+    }
+
     @SneakyThrows
     private String createAndAuthorizePayment(String providerId, CurrencyCode currencyCode, URI returnUri) {
         MerchantAccount account = getMerchantAccount(currencyCode);
+
+        AccountIdentifier accountIdentifier = SortCodeAccountNumberAccountIdentifier.builder()
+                .accountNumber("31510604")
+                .sortCode("100000")
+                .build();
+        if (currencyCode == CurrencyCode.EUR) {
+            accountIdentifier =
+                    IbanAccountIdentifier.iban().iban("FI4950009420028730").build();
+        }
 
         CreatePaymentRequest paymentRequest = CreatePaymentRequest.builder()
                 .amountInMinor(ThreadLocalRandom.current().nextInt(50, 500))
@@ -58,11 +88,8 @@ public class SignupPlusAcceptanceTests extends AcceptanceTests {
                                 .schemeSelection(
                                         SchemeSelection.instantPreferred().build())
                                 .remitter(Remitter.builder()
-                                        .accountHolderName("Andrea Di Lisio")
-                                        .accountIdentifier(SortCodeAccountNumberAccountIdentifier.builder()
-                                                .accountNumber("12345678")
-                                                .sortCode("123456")
-                                                .build())
+                                        .accountHolderName("John Doe")
+                                        .accountIdentifier(accountIdentifier)
                                         .build())
                                 .build())
                         .beneficiary(Beneficiary.merchantAccount()

--- a/src/test/java/com/truelayer/java/signupplus/SignupPlusHandlerTests.java
+++ b/src/test/java/com/truelayer/java/signupplus/SignupPlusHandlerTests.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.verify;
 
 import com.truelayer.java.Constants;
 import com.truelayer.java.entities.RequestScopes;
+import com.truelayer.java.signupplus.entities.GenerateAuthUriRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,9 +33,19 @@ public class SignupPlusHandlerTests {
 
     @Test
     @DisplayName("It should call the get user data by payment endpoint")
-    public void shouldCallCreatePayoutEndpoint() {
+    public void shouldCallGetUserDataByPaymentEndpoint() {
         sut.getUserDataByPayment(A_PAYMENT_ID);
 
         verify(signupPlusApiMock, times(1)).getUserDataByPayment(SCOPES, A_PAYMENT_ID);
+    }
+
+    @Test
+    @DisplayName("It should call the generate auth URI endpoint")
+    public void shouldCallGenerateAuthUriEndpoint() {
+        var generateAuthUriRequest =
+                GenerateAuthUriRequest.builder().paymentId(A_PAYMENT_ID).build();
+        sut.generateAuthUri(generateAuthUriRequest);
+
+        verify(signupPlusApiMock, times(1)).generateAuthUri(SCOPES, generateAuthUriRequest);
     }
 }

--- a/src/test/resources/__files/signup_plus/200.generate_auth_uri.json
+++ b/src/test/resources/__files/signup_plus/200.generate_auth_uri.json
@@ -1,0 +1,3 @@
+{
+  "auth_uri": "https://truelayer.com/redirect?id=863619242079485953&uuid=b912cc0d-149b-40a2-8a24-79a9d1f0913e"
+}


### PR DESCRIPTION
# Description

I've realised that in #322 I've forgotten adding the support for this auth URI generation endpoint 😞 .
This PR really adds that.

## Type of change

Please select multiple options if required.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have updated the `gradle.properties` file with the new version
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the relevant documentation