### PR TITLE
[ACL-296] Move publishing to Maven Central

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -17,8 +17,6 @@ on:
     secrets:
       maven_central_username:
         required: true
-      test:
-        required: false
       maven_central_password:
         required: true
       maven_central_signing_key:
@@ -60,7 +58,6 @@ jobs:
       - name: Publish snapshot to Maven Central
         run: ./gradlew -Pversion=${{env.project_version_snapshot}} publishToMavenCentral
         env:
-          TEST: ${{ secrets.test }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.maven_central_username }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.maven_central_password }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.maven_central_signing_key }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,5 +1,7 @@
-# Reusable workflow to release to Nexus snapshot repository, referenced by workflow-*.yml pipelines.
-name: Release to Nexus snapshots repository
+# Reusable workflow to release to Maven Central, referenced by workflow-*.yml pipelines.
+name: Release to Maven Central
+permissions:
+  contents: read
 
 on:
   workflow_call:
@@ -17,10 +19,18 @@ on:
         required: true
       sonatype_password:
         required: true
+      maven_central_username:
+        required: true
+      maven_central_password:
+        required: true
+      maven_central_signing_key:
+        required: true
+      maven_central_signing_key_password:
+        required: true
 
 jobs:
   release-snapshot:
-    name: Release to Nexus snapshots repository
+    name: Release to Maven Central
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,8 +59,12 @@ jobs:
           else
               echo "Project version ${{env.project_version_snapshot}} is not valid"; exit 1;
           fi
-      - name: Publish to Sonatype snapshot repository
-        run: ./gradlew -Pversion=${{env.project_version_snapshot}} publishToSonatype
+      - name: Publish snapshot to Maven Central
+        run: ./gradlew -Pversion=${{env.project_version_snapshot}} publishToMavenCentral
         env:
           SONATYPE_USERNAME: ${{ secrets.sonatype_username }}
           SONATYPE_PASSWORD: ${{ secrets.sonatype_password }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.maven_central_username }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.maven_central_password }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.maven_central_signing_key }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.maven_central_signing_key_password }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -17,6 +17,8 @@ on:
     secrets:
       maven_central_username:
         required: true
+      test:
+        required: false
       maven_central_password:
         required: true
       maven_central_signing_key:
@@ -58,6 +60,7 @@ jobs:
       - name: Publish snapshot to Maven Central
         run: ./gradlew -Pversion=${{env.project_version_snapshot}} publishToMavenCentral
         env:
+          TEST: ${{ secrets.test }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.maven_central_username }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.maven_central_password }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.maven_central_signing_key }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -15,10 +15,6 @@ on:
         required: true
         type: string
     secrets:
-      sonatype_username:
-        required: true
-      sonatype_password:
-        required: true
       maven_central_username:
         required: true
       maven_central_password:
@@ -62,8 +58,6 @@ jobs:
       - name: Publish snapshot to Maven Central
         run: ./gradlew -Pversion=${{env.project_version_snapshot}} publishToMavenCentral
         env:
-          SONATYPE_USERNAME: ${{ secrets.sonatype_username }}
-          SONATYPE_PASSWORD: ${{ secrets.sonatype_password }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.maven_central_username }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.maven_central_password }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.maven_central_signing_key }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -40,8 +40,6 @@ jobs:
       checkout_ref: ${{ github.ref }}
       project_version: ${{ needs.build-test-coverage.outputs.project_version }}
     secrets:
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_password: ${{ secrets.SONATYPE_PASSWORD }}
       maven_central_username: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
       maven_central_password: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword}}
       maven_central_signing_key: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -40,7 +40,6 @@ jobs:
       checkout_ref: ${{ github.ref }}
       project_version: ${{ needs.build-test-coverage.outputs.project_version }}
     secrets:
-      test: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
       maven_central_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       maven_central_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       maven_central_signing_key: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -32,9 +32,7 @@ jobs:
       tl_signing_key_id: ${{ secrets.ACCEPTANCE_TEST_SIGNING_KEY_ID }}
       tl_signing_private_key: ${{ secrets.ACCEPTANCE_TEST_SIGNING_PRIVATE_KEY }}
   release-snapshot:
-    # TODO: temp
-    #needs: [build-test-coverage, acceptance-tests]
-    needs: build-test-coverage
+    needs: [build-test-coverage, acceptance-tests]
     uses: ./.github/workflows/release-snapshot.yml
     with:
       checkout_ref: ${{ github.ref }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -3,6 +3,10 @@
 # Build, test, run coverage analysis and release to Maven Central a final release.
 name: Workflow on internal branch, excluding main
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches-ignore:
@@ -28,7 +32,9 @@ jobs:
       tl_signing_key_id: ${{ secrets.ACCEPTANCE_TEST_SIGNING_KEY_ID }}
       tl_signing_private_key: ${{ secrets.ACCEPTANCE_TEST_SIGNING_PRIVATE_KEY }}
   release-snapshot:
-    needs: [build-test-coverage, acceptance-tests]
+    # TODO: temp
+    #needs: [build-test-coverage, acceptance-tests]
+    needs: build-test-coverage
     uses: ./.github/workflows/release-snapshot.yml
     with:
       checkout_ref: ${{ github.ref }}
@@ -36,3 +42,7 @@ jobs:
     secrets:
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
       sonatype_password: ${{ secrets.SONATYPE_PASSWORD }}
+      maven_central_username: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
+      maven_central_password: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword}}
+      maven_central_signing_key: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
+      maven_central_signing_key_password: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -32,9 +32,7 @@ jobs:
       tl_signing_key_id: ${{ secrets.ACCEPTANCE_TEST_SIGNING_KEY_ID }}
       tl_signing_private_key: ${{ secrets.ACCEPTANCE_TEST_SIGNING_PRIVATE_KEY }}
   release-snapshot:
-    #TODO fix
-    #needs: [build-test-coverage, acceptance-tests]
-    needs: [ build-test-coverage ]
+    needs: [build-test-coverage, acceptance-tests]
     uses: ./.github/workflows/release-snapshot.yml
     with:
       checkout_ref: ${{ github.ref }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -38,7 +38,7 @@ jobs:
       checkout_ref: ${{ github.ref }}
       project_version: ${{ needs.build-test-coverage.outputs.project_version }}
     secrets:
-      maven_central_username: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
-      maven_central_password: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword}}
-      maven_central_signing_key: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
-      maven_central_signing_key_password: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}
+      maven_central_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      maven_central_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      maven_central_signing_key: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY }}
+      maven_central_signing_key_password: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY_PASSWORD }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -34,6 +34,7 @@ jobs:
   release-snapshot:
     #TODO fix
     #needs: [build-test-coverage, acceptance-tests]
+    needs: [ build-test-coverage ]
     uses: ./.github/workflows/release-snapshot.yml
     with:
       checkout_ref: ${{ github.ref }}

--- a/.github/workflows/workflow-branch.yml
+++ b/.github/workflows/workflow-branch.yml
@@ -32,12 +32,14 @@ jobs:
       tl_signing_key_id: ${{ secrets.ACCEPTANCE_TEST_SIGNING_KEY_ID }}
       tl_signing_private_key: ${{ secrets.ACCEPTANCE_TEST_SIGNING_PRIVATE_KEY }}
   release-snapshot:
-    needs: [build-test-coverage, acceptance-tests]
+    #TODO fix
+    #needs: [build-test-coverage, acceptance-tests]
     uses: ./.github/workflows/release-snapshot.yml
     with:
       checkout_ref: ${{ github.ref }}
       project_version: ${{ needs.build-test-coverage.outputs.project_version }}
     secrets:
+      test: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
       maven_central_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       maven_central_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       maven_central_signing_key: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY }}

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           tag_name: ${{ steps.create_tag.outputs.new_tag }}
           generate_release_notes: true
-      - name: Publish to Sonatype and Maven Central
+      - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY_PASSWORD }}

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          checkout_ref: ${{ github.ref }}
+          ref: ${{ github.ref }}
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
@@ -56,9 +56,9 @@ jobs:
           tag_name: ${{ steps.create_tag.outputs.new_tag }}
           generate_release_notes: true
       - name: Publish to Sonatype and Maven Central
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishToMavenCentral
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-          SONATYPE_GPG_PASSPHRASE: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}

--- a/.github/workflows/workflow-pr-fork.yml
+++ b/.github/workflows/workflow-pr-fork.yml
@@ -52,7 +52,7 @@ jobs:
       checkout_ref: ${{ github.event.pull_request.head.sha }}
       project_version: ${{ needs.build-test-coverage.outputs.project_version }}
     secrets:
-      maven_central_username: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
-      maven_central_password: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword}}
-      maven_central_signing_key: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
-      maven_central_signing_key_password: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}
+      maven_central_username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      maven_central_password: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      maven_central_signing_key: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY }}
+      maven_central_signing_key_password: ${{ secrets.PGP_SIGNING_IN_MEMORY_KEY_PASSWORD }}

--- a/.github/workflows/workflow-pr-fork.yml
+++ b/.github/workflows/workflow-pr-fork.yml
@@ -52,5 +52,7 @@ jobs:
       checkout_ref: ${{ github.event.pull_request.head.sha }}
       project_version: ${{ needs.build-test-coverage.outputs.project_version }}
     secrets:
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_password: ${{ secrets.SONATYPE_PASSWORD }}
+      maven_central_username: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralUsername }}
+      maven_central_password: ${{ secrets.ORG_GRADLE_PROJECT_mavenCentralPassword}}
+      maven_central_signing_key: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
+      maven_central_signing_key_password: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use on of those release with Gradle, make sure you have the following reposit
 repositories {
     // ... all your existing repos here
     
-     maven {
+    maven {
         url = 'https://central.sonatype.com/repository/maven-snapshots/'
     }  
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ repositories {
     
     maven {
         url = 'https://central.sonatype.com/repository/maven-snapshots/'
-    }  
+    }
 }
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ To use on of those release with Gradle, make sure you have the following reposit
 repositories {
     // ... all your existing repos here
     
-    maven{
-        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-    }   
+     maven {
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+    }  
 }
 ``` 
 

--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ tasks.register('javadocJar', Jar) {
 }
 
 mavenPublishing {
-    publishToMavenCentral()
+    publishToMavenCentral(true)
     signAllPublications()
 
     // Use the sources and javadoc jars

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ plugins {
     //  test coverage
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.2'
-    // signing
-    id 'signing'
     // maven central publishing
     id "com.vanniktech.maven.publish" version "0.34.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,21 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+
 plugins {
     id 'java-library'
     // to unleash the lombok magic
     id "io.freefair.lombok" version "8.13.1"
     // to make our tests output more fancy
     id 'com.adarshr.test-logger' version '4.0.0'
-    // to publish packages
-    id 'maven-publish'
     // code linting
     id "com.diffplug.spotless" version "7.0.3"
     //  test coverage
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.2'
     // signing
-    id "signing"
-    // nexus publishing
-    id "io.github.gradle-nexus.publish-plugin"  version "2.0.0"
+    id 'signing'
+    // maven central publishing
+    id "com.vanniktech.maven.publish" version "0.34.0"
 }
 
 compileJava {
@@ -28,7 +29,8 @@ spotless {
     }
 }
 
-task createProperties(dependsOn: processResources) {
+tasks.register('createProperties') {
+    dependsOn processResources
     doLast {
         file("${layout.buildDirectory.get()}/resources/main/truelayer-java.version.properties").withWriter { w ->
             Properties p = new Properties()
@@ -147,66 +149,45 @@ jacocoTestReport {
     }
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     from sourceSets.main.allJava
     archiveClassifier = 'sources'
 }
 
-task javadocJar(type: Jar) {
+tasks.register('javadocJar', Jar) {
     from javadoc
     archiveClassifier = 'javadoc'
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from(components.java)
-            artifact sourcesJar
-            artifact javadocJar
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
 
-            pom {
-                name = project_name
-                packaging = 'jar'
-                description = project_description
-                url = project_url
-                scm {
-                    connection = project_scm
-                    developerConnection = project_scm
-                    url = project_url
-                }
-                licenses {
-                    license {
-                        name = project_license_name
-                        url = project_license_url
-                    }
-                }
-                developers {
-                    developer {
-                        id = project_developer
-                        name = project_developer
-                    }
-                }
+    // Use the sources and javadoc jars
+    configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
+
+    pom {
+        name = project_name
+        packaging = 'jar'
+        description = project_description
+        url = project_url
+        scm {
+            connection = project_scm
+            url = project_url
+        }
+        licenses {
+            license {
+                name = project_license_name
+                url = project_license_url
+                distribution = project_license_url
             }
         }
-    }
-}
-
-ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-signing {
-    def signingKey = System.getenv('SONATYPE_GPG_KEY')
-    def signingPassword = System.getenv('SONATYPE_GPG_PASSPHRASE')
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
-    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri(sonatype_repository_url)
-            snapshotRepositoryUrl = uri(sonatype_snapshot_repository_url)
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_PASSWORD")
+        developers {
+            developer {
+                id = developer_name
+                name = developer_name
+                url = developer_url
+            }
         }
     }
 }

--- a/examples/quarkus-mvc/build.gradle
+++ b/examples/quarkus-mvc/build.gradle
@@ -8,6 +8,10 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+    }
 }
 
 dependencies {

--- a/examples/quarkus-mvc/build.gradle
+++ b/examples/quarkus-mvc/build.gradle
@@ -8,10 +8,6 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-        name = 'Central Portal Snapshots'
-        url = 'https://central.sonatype.com/repository/maven-snapshots/'
-    }
 }
 
 dependencies {

--- a/examples/quarkus-mvc/src/main/java/com/truelayer/quarkusmvc/services/DonationService.java
+++ b/examples/quarkus-mvc/src/main/java/com/truelayer/quarkusmvc/services/DonationService.java
@@ -63,10 +63,10 @@ public class DonationService implements IDonationService {
             throw new RuntimeException(String.format("create payment error: %s", paymentResponse.getError()));
         }
 
-        return tlClient.hpp()
-                .getHostedPaymentPageLink(
-                        paymentResponse.getData().getId(),
-                        paymentResponse.getData().getResourceToken(),
-                        URI.create("http://localhost:8080/donations/callback"));
+        return tlClient.hppLinkBuilder()
+                .resourceId(paymentResponse.getData().getId())
+                .resourceToken(paymentResponse.getData().getResourceToken())
+                .returnUri(URI.create("http://localhost:8080/donations/callback"))
+                .build();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,14 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=17.3.0
+version=17.3.1
 
 # Artifacts properties
-sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
-sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/
 project_name=TrueLayer Java
 project_description=TrueLayer Java SDK for https://truelayer.com
 project_url=https://github.com/TrueLayer/truelayer-java
+project_scm=scm:git:https://github.com/TrueLayer/truelayer-java.git
 project_license_url=https://raw.githubusercontent.com/TrueLayer/truelayer-java/main/LICENSE
 project_license_name=MIT License
-project_developer=truelayer
-project_scm=scm:git:https://github.com/TrueLayer/truelayer-java.git
+developer_name=truelayer
+developer_url=https://github.com/TrueLayer


### PR DESCRIPTION
This PR migrates the publishing pipeline from Bintray/JCenter to Maven Central using the vanniktech gradle-maven-publish-plugin and resolves the 403 errors we were experiencing with the previous publishing setup.

## Background
The Nexus Repository Manager v2 and dependent services, including OSSRH, [reached end-of-life on June 30, 2025.](https://central.sonatype.org/pages/ossrh-eol/) This necessitated the migration to either a newer version of Nexus Sonatype(v3) or to Maven Central for our publishing pipeline. 

Considering that: 
- We don't really take advantage of Nexus Sonatype at the minute, but we have been using it just as proxy to Maven central
- When we originally set up the release pipeline, we would have considered publishing directly to Maven Central, but at the time, the only way to automate this process was to publish to Nexus Sonatype and have that streaming artifacts to Maven central. This problem does not apply anymore nowadays, given that the Maven Central Portal has now APIs that we can integrate in our pipeline

I'm proposing to move our publishing directly to Maven Central. 

## Changes for us
- Added vanniktech gradle-maven-publish-plugin for Maven Central publishing
- Updated CI workflows to support the new publishing mechanism
- Configured proper signing and publishing settings for Maven Central
- Enabled signing with signAllPublications()

## Impact for customers

Customers don't have to change anything to use stable releases of the library. 
There's only a consequence for customers making use of SNAPSHOTs releases: As mentioned in our README, they will have to use the updated repository link in their projects. 

## Migration Guide
This implementation follows the official migration guide: https://vanniktech.github.io/gradle-maven-publish-plugin/central/

For signing key configuration, this helpful comment was referenced: https://github.com/vanniktech/gradle-maven-publish-plugin/pull/201#discussion_r584270633. More precisely, that thread helped me understanding the expected format for the key expected by the publishing plugin.