### PR TITLE
[ACL-312] Update Maven Central badge URL to Sonatype Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [17.5.0]
+## [17.5.1] - 2025-10-31
+### Fixed
+* Update Sonatype Central badge url in order to show latest version
+
+## [17.5.0] - 2025-10-24
 ### Added
 * Add support for Verified Payouts with user-determined beneficiary type
 * Add HPP link builder support for payouts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TrueLayer Java
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.truelayer/truelayer-java/badge.svg?style=flat)](https://search.maven.org/artifact/com.truelayer/truelayer-java)
+[![Maven Central](https://maven-badges.sml.io/sonatype-central/com.truelayer/truelayer-java/badge.svg?style=flat)](https://central.sonatype.com/artifact/com.truelayer/truelayer-java)
 [![javadoc](https://javadoc.io/badge2/com.truelayer/truelayer-java/javadoc.svg)](https://javadoc.io/doc/com.truelayer/truelayer-java)
 [![Coverage Status](https://coveralls.io/repos/github/TrueLayer/truelayer-java/badge.svg?t=gcGKQv)](https://coveralls.io/github/TrueLayer/truelayer-java)
 [![Scheduled acceptance tests in Sandbox environment](https://github.com/TrueLayer/truelayer-java/actions/workflows/workflow-scheduled-acceptance-tests.yml/badge.svg)](https://github.com/TrueLayer/truelayer-java/actions/workflows/workflow-scheduled-acceptance-tests.yml)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Main properties
 group=com.truelayer
 archivesBaseName=truelayer-java
-version=17.5.0
+version=17.5.1
 
 # Artifacts properties
 project_name=TrueLayer Java


### PR DESCRIPTION
## Summary
* Updates the Maven Central badge URL in README.md to use the new Sonatype Central service
* The legacy `maven-badges.herokuapp.com` URL has been replaced with `maven-badges.sml.io` (see [here](https://github.com/softwaremill/maven-badges?tab=readme-ov-file#a-new-dns-address))
* Updates version to 17.5.1
* Updates CHANGELOG with the fix

## Context
The old Maven Central badge URL was no longer displaying the latest version correctly (specifically, this stopped working after we updated the way we were publishing on Maven central with [this PR](https://github.com/TrueLayer/truelayer-java/pull/367)). This PR updates it to use the new Sonatype Central service URL to ensure the badge continues to function properly.

## Test plan
- [x] Verify the new badge URL displays correctly in the README
- [x] Confirm the badge shows the current version (17.5.0)
- [x] Check that clicking the badge links to the correct Maven Central artifact page

🤖 Generated with [Claude Code](https://claude.com/claude-code)